### PR TITLE
Fixed linux x86_64 Node.js server definition. The old definition had wro...

### DIFF
--- a/eclipse/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/plugin.xml
+++ b/eclipse/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/plugin.xml
@@ -17,9 +17,9 @@
 >
 
 	<extension point="tern.eclipse.ide.server.nodejs.core.nodeJSInstalls" >
-		<install id="node-v0.10.22-darwin-x64"
+		<install id="node-v0.10.22-linux-x86_64"
 				 name="%nodeJSInstall_v0.10.22.name"
-				 path="/nodejs/node-v0.10.22-darwin-x64/bin" />
+				 path="/nodejs/node-v0.10.22-linux-x86_64/bin" />
 	 </extension>
 	  
 </plugin>        


### PR DESCRIPTION
...ng path to the server.

When trying to use pre-installed Node.js (Window->Preferences->Tern->Node.js->Node.js install preference == "Node.js v0.10.22 - linux.gtk.x86_64") I'm getting the following exceptions in Error Log:
!ENTRY tern.eclipse.ide.core 4 0 2014-02-26 03:28:43.378
!MESSAGE Cannot run program "/home/jeremy/projects/tern.java/eclipse/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/nodejs/node-v0.10.22-darwin-x64/bin/node" (in directory "/home/jeremy/projects/webtools/runtime-Cordova/cordova-app-hello-world"): error=2, No such file or directory

!ENTRY tern.eclipse.ide.jsdt 4 0 2014-02-26 03:28:43.395
!MESSAGE Error while JSDT Tern completion.
!STACK 0
tern.TernException: java.io.IOException: Cannot run program "/home/jeremy/projects/tern.java/eclipse/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/nodejs/node-v0.10.22-darwin-x64/bin/node" (in directory "/home/jeremy/projects/webtools/runtime-Cordova/cordova-app-hello-world"): error=2, No such file or directory
    at tern.server.nodejs.NodejsTernServer.request(NodejsTernServer.java:249)
    at tern.eclipse.ide.core.IDETernProject.request(IDETernProject.java:425)
    at tern.eclipse.ide.core.IDETernProject.request(IDETernProject.java:419)
    at tern.eclipse.ide.jsdt.internal.TernCompletionProposalComputer.computeCompletionProposals(TernCompletionProposalComputer.java:83)
    at org.eclipse.wst.jsdt.internal.ui.text.java.CompletionProposalComputerDescriptor.computeCompletionProposals(CompletionProposalComputerDescriptor.java:298)
    at org.eclipse.wst.jsdt.internal.ui.text.java.CompletionProposalCategory.computeCompletionProposals(CompletionProposalCategory.java:258)
    at org.eclipse.wst.jsdt.internal.ui.text.java.ContentAssistProcessor.collectProposals(ContentAssistProcessor.java:244)
    at org.eclipse.wst.jsdt.internal.ui.text.java.ContentAssistProcessor.computeCompletionProposals(ContentAssistProcessor.java:213)
    at org.eclipse.jface.text.contentassist.ContentAssistant.computeCompletionProposals(ContentAssistant.java:1861)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.computeProposals(CompletionProposalPopup.java:568)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.access$16(CompletionProposalPopup.java:565)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup$2.run(CompletionProposalPopup.java:500)
    at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.showProposals(CompletionProposalPopup.java:494)
    at org.eclipse.jface.text.contentassist.ContentAssistant.showPossibleCompletions(ContentAssistant.java:1687)
    at org.eclipse.wst.jsdt.internal.ui.javaeditor.CompilationUnitEditor$AdaptedSourceViewer.doOperation(CompilationUnitEditor.java:168)
    at org.eclipse.ui.texteditor.ContentAssistAction$1.run(ContentAssistAction.java:82)
    at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
    at org.eclipse.ui.texteditor.ContentAssistAction.run(ContentAssistAction.java:80)
    at org.eclipse.jface.action.Action.runWithEvent(Action.java:499)
    at org.eclipse.jface.commands.ActionHandler.execute(ActionHandler.java:120)
    at org.eclipse.ui.internal.handlers.E4HandlerProxy.execute(E4HandlerProxy.java:90)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:56)
    at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:243)
    at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:224)
    at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:132)
    at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:163)
    at org.eclipse.core.commands.Command.executeWithChecks(Command.java:499)
    at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:508)
    at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:222)
    at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.executeCommand(KeyBindingDispatcher.java:285)
    at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.press(KeyBindingDispatcher.java:505)
    at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.processKeyEvent(KeyBindingDispatcher.java:556)
    at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.filterKeySequenceBindings(KeyBindingDispatcher.java:377)
    at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher.access$0(KeyBindingDispatcher.java:323)
    at org.eclipse.e4.ui.bindings.keys.KeyBindingDispatcher$KeyDownFilter.handleEvent(KeyBindingDispatcher.java:85)
    at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
    at org.eclipse.swt.widgets.Display.filterEvent(Display.java:1569)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1387)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1412)
    at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1397)
    at org.eclipse.swt.widgets.Widget.sendKeyEvent(Widget.java:1424)
    at org.eclipse.swt.widgets.Widget.gtk_key_press_event(Widget.java:824)
    at org.eclipse.swt.widgets.Control.gtk_key_press_event(Control.java:3266)
    at org.eclipse.swt.widgets.Composite.gtk_key_press_event(Composite.java:777)
    at org.eclipse.swt.widgets.Widget.windowProc(Widget.java:2088)
    at org.eclipse.swt.widgets.Control.windowProc(Control.java:5498)
    at org.eclipse.swt.widgets.Display.windowProc(Display.java:4637)
    at org.eclipse.swt.internal.gtk.OS._gtk_main_do_event(Native Method)
    at org.eclipse.swt.internal.gtk.OS.gtk_main_do_event(OS.java:8727)
    at org.eclipse.swt.widgets.Display.eventProc(Display.java:1248)
    at org.eclipse.swt.internal.gtk.OS._g_main_context_iteration(Native Method)
    at org.eclipse.swt.internal.gtk.OS.g_main_context_iteration(OS.java:2283)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3389)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1122)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1006)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:146)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:615)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:566)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:125)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:109)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:80)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:372)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:226)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:636)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:591)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1450)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1426)
Caused by: java.io.IOException: Cannot run program "/home/jeremy/projects/tern.java/eclipse/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/nodejs/node-v0.10.22-darwin-x64/bin/node" (in directory "/home/jeremy/projects/webtools/runtime-Cordova/cordova-app-hello-world"): error=2, No such file or directory
    at java.lang.ProcessBuilder.start(ProcessBuilder.java:1042)
    at tern.server.nodejs.process.NodejsProcess.start(NodejsProcess.java:269)
    at tern.server.nodejs.process.NodejsProcess.start(NodejsProcess.java:294)
    at tern.server.nodejs.NodejsTernServer.getBaseURL(NodejsTernServer.java:182)
    at tern.server.nodejs.NodejsTernServer.makeRequest(NodejsTernServer.java:161)
    at tern.server.nodejs.NodejsTernServer.request(NodejsTernServer.java:222)
    ... 79 more
Caused by: java.io.IOException: error=2, No such file or directory
    at java.lang.UNIXProcess.forkAndExec(Native Method)
    at java.lang.UNIXProcess.<init>(UNIXProcess.java:135)
    at java.lang.ProcessImpl.start(ProcessImpl.java:130)
    at java.lang.ProcessBuilder.start(ProcessBuilder.java:1023)
    ... 84 more
