### PR TITLE
Compilation Error in Luna and the latest org.apache.httpcpmponents.httpc...

### DIFF
--- a/core/tern.server.nodejs/src/tern/server/nodejs/NodejsTernHelper.java
+++ b/core/tern.server.nodejs/src/tern/server/nodejs/NodejsTernHelper.java
@@ -149,7 +149,7 @@ public class NodejsTernHelper {
 	private static HttpPost createHttpPost(String baseURL, JSONObject doc)
 			throws UnsupportedEncodingException {
 		HttpPost httpPost = new HttpPost(baseURL);
-		httpPost.setEntity(new StringEntity(doc.toJSONString(), null));
+		httpPost.setEntity(new StringEntity(doc.toJSONString()));
 		return httpPost;
 	}
 


### PR DESCRIPTION
...ore bundle of v.4.2.4

Looks like the latest more has constructors defined for org.apache.http.entity.StringEntity class and,
as the result, I'm getting the following error while trying to build Tern.java in my Luna and the latest
Orbit bundle:

Description    Resource    Path    Location    Type
The constructor StringEntity(String, ContentType) is ambiguous    NodejsTernHelper.java    /tern.server.nodejs/src/tern/server/nodejs    line 152    Java Problem

There is StringEntity(String) constructor that could be used for the same purposes in that newest bundle as well as in the v.4.1.4.
When I'm using it instead of StringEntity(String, ContentType) I can successfully build the project either in Luna (with latest Orbit) as well as
by tycho (which uses Kepler and o.a.httpcomponents.httpcore v.4.1.4).

Signed-off-by: vrubezhny vrubezhny@exadel.com
