### PR TITLE
Deadlock in AngularJS-eclipse/Tern.java

### DIFF
--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 Angelo ZERR.
+ * Copyright (c) 2013, 2014 Angelo ZERR.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,6 +53,9 @@ public final class TernUIMessages extends NLS {
 	public static String TernHyperlink_typeLabel;
 	public static String TernHyperlink_text;
 
+	// Tern Console Name
+	public static String TernConsoleJob_name;
+	
 	private TernUIMessages() {
 	}
 

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.properties
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.properties
@@ -36,3 +36,6 @@ MultipleFolderSelectionDialog_button=Create &New Folder...
 # Hyperlink
 TernHyperlink_typeLabel=Tern Hyperlink
 TernHyperlink_text=Tern - Go to definition
+
+#Console Job Name
+TernConsoleJob_name=Tern Console Job

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/console/TernConsole.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/console/TernConsole.java
@@ -1,5 +1,9 @@
 package tern.eclipse.ide.internal.ui.console;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
@@ -9,6 +13,7 @@ import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.MessageConsole;
 import org.eclipse.ui.console.MessageConsoleStream;
 
+import tern.eclipse.ide.internal.ui.TernUIMessages;
 import tern.eclipse.ide.ui.ImageResource;
 import tern.eclipse.ide.ui.console.ITernConsole;
 import tern.eclipse.ide.ui.console.LineType;
@@ -93,7 +98,20 @@ public class TernConsole extends MessageConsole implements ITernConsole {
 	}
 
 	@Override
-	public void doAppendLine(LineType lineType, String line) {
+	public void doAppendLine(final LineType lineType, final String line) {
+		Job appendJob = new Job (TernUIMessages.TernConsoleJob_name) {
+
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				internalDoAppendLine(lineType, line);
+				return Status.OK_STATUS;
+			}
+		};
+		appendJob.setPriority(Job.LONG);
+		appendJob.schedule();
+	}
+	
+	private void internalDoAppendLine(LineType lineType, String line) {
 		showConsole();
 		synchronized (document) {
 			if (visible) {


### PR DESCRIPTION
TernConsole is fixed due not to block on UI tread

Signed-off-by: vrubezhny vrubezhny@exadel.com
https://github.com/angelozerr/angularjs-eclipse/issues/27
