### PR TITLE
Make Tern.java to be able to treat a custom project nature as Tern nature

### DIFF
--- a/eclipse/tern.eclipse.ide.core/plugin.properties
+++ b/eclipse/tern.eclipse.ide.core/plugin.properties
@@ -14,6 +14,7 @@ providerName=Angelo ZERR
 # Extension point
 ternServerTypes.name=Tern Server Types.
 ternConsoleConnectors.name=Tern Console Connectors.
+ternServerAdapters.name=Tern Nature Adapters
 
 # Nature
 ternNature.name=Tern Nature

--- a/eclipse/tern.eclipse.ide.core/plugin.xml
+++ b/eclipse/tern.eclipse.ide.core/plugin.xml
@@ -18,6 +18,8 @@
 		schema="schema/ternServerTypes.exsd" />	
 	<extension-point id="ternConsoleConnectors" name="%ternConsoleConnectors.name"
 		schema="schema/ternConsoleConnectors.exsd" />	
+	<extension-point id="ternNatureAdapters" name="%ternNatureAdapters.name"
+		schema="schema/ternNatureAdapters.exsd" />	
 	
 	<!-- =================================================================================== -->
 	<!-- Tern Builder                                                                        -->

--- a/eclipse/tern.eclipse.ide.core/schema/ternNatureAdapters.exsd
+++ b/eclipse/tern.eclipse.ide.core/schema/ternNatureAdapters.exsd
@@ -1,0 +1,87 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="tern.eclipse.ide.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="tern.eclipse.ide.core" id="ternNatureAdapters" name="Tern Nature Adapters"/>
+      </appInfo>
+      <documentation>
+         Extension point to provide Natures that are to be treated as the Tern ones.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="ternAdaptToNature" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  a fully-qualified name of the target extension point
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  an optional id
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  an optional name
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="ternAdaptToNature">
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  ID of the Nature to be treated as the Tern one
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  an optional name
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         2.0
+      </documentation>
+   </annotation>
+
+
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         This plugin itself does not have any predefined builders.
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/eclipse/tern.eclipse.ide.ui/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.ui/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.editors,
  org.eclipse.jface.text,
  org.eclipse.ui.workbench.texteditor,
- tern.eclipse;bundle-version="0.2.0"
+ tern.eclipse;bundle-version="0.2.0",
+ org.eclipse.core.expressions
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tern.eclipse.ide.ui.TernUIPlugin
 Import-Package: org.json.simple

--- a/eclipse/tern.eclipse.ide.ui/plugin.xml
+++ b/eclipse/tern.eclipse.ide.ui/plugin.xml
@@ -13,6 +13,22 @@
 ###############################################################################
  -->
 <plugin>
+	
+    <extension point="org.eclipse.ui.startup">
+        <startup
+            class="tern.eclipse.ide.ui.internal.TernIDEStartup">
+        </startup>
+    </extension> 
+    
+	<extension point="org.eclipse.core.expressions.propertyTesters">
+		<propertyTester
+			id="tern.eclipse.ide.ui.TernNatureTester"
+			type="org.eclipse.core.resources.IResource"
+			namespace="tern.eclipse.ide.ui"
+			properties="isTernProject"
+			class="tern.eclipse.ide.ui.internal.TernNatureTester">
+		</propertyTester>
+	</extension>
 	    
 	<!--Commands:-->
 	
@@ -40,8 +56,7 @@
 						<adapt type="org.eclipse.core.resources.IProject">
 							<and>
 								<not>
-									<test property="org.eclipse.core.resources.projectNature"
-										  value="tern.eclipse.ide.core.ternnature"/>
+									<test property="tern.eclipse.ide.ui.isTernProject" />
 								</not>
 							</and>
 						</adapt>
@@ -85,8 +100,7 @@
             id="tern.eclipse.ide.internal.ui.properties.TernMainPropertyPage">
          <enabledWhen>
 		     <adapt type="org.eclipse.core.resources.IProject">
-		          <test property="org.eclipse.core.resources.projectNature" 
-		          		value="tern.eclipse.ide.core.ternnature"/>
+                  <test property="tern.eclipse.ide.ui.isTernProject" />
 		     </adapt>         
          </enabledWhen>
       </page>
@@ -97,8 +111,7 @@
             id="tern.eclipse.ide.internal.ui.properties.TernTypeDefinitionsPropertyPage">
          <enabledWhen>
 		     <adapt type="org.eclipse.core.resources.IProject">
-		          <test property="org.eclipse.core.resources.projectNature" 
-		          		value="tern.eclipse.ide.core.ternnature"/>
+                  <test property="tern.eclipse.ide.ui.isTernProject" />
 		     </adapt>         
          </enabledWhen>
       </page>      
@@ -109,8 +122,7 @@
             id="tern.eclipse.ide.internal.ui.properties.TernPluginsPropertyPage">
          <enabledWhen>
 		     <adapt type="org.eclipse.core.resources.IProject">
-		          <test property="org.eclipse.core.resources.projectNature" 
-		          		value="tern.eclipse.ide.core.ternnature"/>
+                  <test property="tern.eclipse.ide.ui.isTernProject" />
 		     </adapt>         
          </enabledWhen>
       </page>     
@@ -121,8 +133,7 @@
             id="tern.eclipse.ide.internal.ui.properties.TernScriptPathsPropertyPage">
          <enabledWhen>
 		     <adapt type="org.eclipse.core.resources.IProject">
-		          <test property="org.eclipse.core.resources.projectNature" 
-		          		value="tern.eclipse.ide.core.ternnature"/>
+                  <test property="tern.eclipse.ide.ui.isTernProject" />
 		     </adapt>         
          </enabledWhen>
       </page>
@@ -133,8 +144,7 @@
             id="tern.eclipse.ide.internal.ui.properties.TernConsolePropertyPage">
          <enabledWhen>
 		     <adapt type="org.eclipse.core.resources.IProject">
-		          <test property="org.eclipse.core.resources.projectNature" 
-		          		value="tern.eclipse.ide.core.ternnature"/>
+                  <test property="tern.eclipse.ide.ui.isTernProject" />
 		     </adapt>         
          </enabledWhen>
       </page>                    		          		  	

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/internal/TernIDEStartup.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/internal/TernIDEStartup.java
@@ -1,0 +1,17 @@
+package tern.eclipse.ide.ui.internal;
+
+import org.eclipse.ui.IStartup;
+
+/**
+ * Need this to make TernNatureTester work from early start
+ * 
+ * @author Victor Rubezhny
+ */
+public class TernIDEStartup implements IStartup {
+	
+	@Override
+	public void earlyStartup() {
+		// Nothing really to do here, but need this to make TernNatureTester work from early start
+	}
+
+}

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/internal/TernNatureTester.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/internal/TernNatureTester.java
@@ -1,0 +1,49 @@
+package tern.eclipse.ide.ui.internal;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdaptable;
+
+import tern.eclipse.ide.core.IDETernProject;
+
+/**
+ * Property Tester for a IProject receiver object
+ * 
+ * Property to be tested: "isTernProject"
+ * 
+ * @author Victor Rubezhny
+ */
+public class TernNatureTester extends org.eclipse.core.expressions.PropertyTester {
+	private static final String IS_TERN_PROJECT_PROPERTY = "isTernProject";
+
+	public TernNatureTester() {
+		// Default constructor is required for property tester
+	}
+
+	/**
+	 * Tests if the receiver object is a project is a Tern project
+	 * 
+	 * @return true if the receiver object is a Project that has a nature that is treated as Tern nature,
+	 * 		   otherwise false is returned 
+	 */
+	@Override
+	public boolean test(Object receiver, String property, Object[] args,
+			Object expectedValue) {
+		
+		if (IS_TERN_PROJECT_PROPERTY.equals(property)) 
+			return testIsTernProject(receiver);
+
+		return false;
+	}
+
+	private boolean testIsTernProject(Object receiver) {
+		if (receiver instanceof IAdaptable) {
+			IProject project = (IProject)((IAdaptable)receiver).getAdapter(IProject.class);
+			if (project != null) {
+				return IDETernProject.hasTernNature(project);
+			}
+		}
+		
+		return false;
+	}
+	
+}


### PR DESCRIPTION
This will allow Tern.java to be seamlessly integrated to other products.

Other products may declare a custom project nature to be treated as a Tern nature by adding the following extension into some plugin.xml:

```
<extension 
    point="tern.eclipse.ide.core.ternNatureAdapters"
    id="com.example.product.tern.ternNatureAdapters"
    name="come.example.product.tern.ternNatureAdapters">

    <ternAdaptToNature 
        id = "com.example.product.someNature"
        name = "Some example project nature ID" />
</extension>
```

Signed-off-by: vrubezhny vrubezhny@exadel.com
