### PR TITLE
Wrong property name for Tern Nature Adapters extension point name

### DIFF
--- a/eclipse/tern.eclipse.ide.core/plugin.properties
+++ b/eclipse/tern.eclipse.ide.core/plugin.properties
@@ -14,7 +14,7 @@ providerName=Angelo ZERR
 # Extension point
 ternServerTypes.name=Tern Server Types.
 ternConsoleConnectors.name=Tern Console Connectors.
-ternServerAdapters.name=Tern Nature Adapters
+ternNatureAdapters.name=Tern Nature Adapters
 
 # Nature
 ternNature.name=Tern Nature


### PR DESCRIPTION
Property name is fixed in plugin.properties

Signed-off-by: vrubezhny vrubezhny@exadel.com
