### PR TITLE
NPE in ImageResource.registerImageDescriptor()

### DIFF
--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/ImageResource.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/ImageResource.java
@@ -158,6 +158,8 @@ public class ImageResource {
 	}
 
 	public static void registerImageDescriptor(String key, ImageDescriptor id) {
+		if (imageRegistry == null)
+			initializeImageRegistry();
 		imageRegistry.put(key, id);
 		imageDescriptors.put(key, id);
 	}


### PR DESCRIPTION
Image Registry is not initialized on a first use, the following exception is thrown as result:

 java.lang.NullPointerException
    at tern.eclipse.ide.ui.ImageResource.registerImageDescriptor(ImageResource.java:161)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptor.getImageKey(TernDescriptor.java:38)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptor.<init>(TernDescriptor.java:21)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.addTernDescriptors(TernDescriptorManager.java:116)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.loadTernDescriptors(TernDescriptorManager.java:101)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.getTernDescriptor(TernDescriptorManager.java:82)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.getImage(TernDescriptorManager.java:72)
    at tern.eclipse.ide.ui.contentassist.JSTernCompletionProposal.getDefaultImage(JSTernCompletionProposal.java:61)
    at tern.eclipse.jface.contentassist.TernCompletionProposal.<init>(TernCompletionProposal.java:56)
    at tern.eclipse.ide.ui.contentassist.JSTernCompletionProposal.<init>(JSTernCompletionProposal.java:50)
    at tern.eclipse.ide.ui.contentassist.JSTernCompletionCollector.addProposal(JSTernCompletionCollector.java:38)
    at tern.server.AbstractTernServer.addProposal(AbstractTernServer.java:103)
    at tern.server.nodejs.NodejsTernServer.request(NodejsTernServer.java:246)
    at tern.eclipse.ide.core.IDETernProject.request(IDETernProject.java:511)
    at tern.eclipse.ide.core.IDETernProject.request(IDETernProject.java:505)
    at tern.eclipse.ide.jsdt.internal.contentassist.TernContentAssistProcessor.computeCompletionProposals(TernContentAssistProcessor.java:78)
    at org.eclipse.wst.sse.ui.internal.contentassist.CompletionProposalComputerDescriptor.computeCompletionProposals(CompletionProposalComputerDescriptor.java:284)
    at org.eclipse.wst.sse.ui.internal.contentassist.CompletionProposalCategory.computeCompletionProposals(CompletionProposalCategory.java:290)
    at org.eclipse.wst.sse.ui.contentassist.StructuredContentAssistProcessor.collectProposals(StructuredContentAssistProcessor.java:484)
    at org.eclipse.wst.sse.ui.contentassist.StructuredContentAssistProcessor.computeCompletionProposals(StructuredContentAssistProcessor.java:255)
    at org.eclipse.wst.sse.ui.internal.contentassist.CompoundContentAssistProcessor.computeCompletionProposals(CompoundContentAssistProcessor.java:127)
    at org.eclipse.jface.text.contentassist.ContentAssistant.computeCompletionProposals(ContentAssistant.java:1861)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.computeProposals(CompletionProposalPopup.java:573)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.access$16(CompletionProposalPopup.java:570)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup$2.run(CompletionProposalPopup.java:505)
    at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.showProposals(CompletionProposalPopup.java:499)
    at org.eclipse.jface.text.contentassist.ContentAssistant$2.run(ContentAssistant.java:378)
    at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
    at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:136)
    at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3781)
    at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3419)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1152)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1033)
    at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:148)
    at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:635)
    at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
    at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:578)
    at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
    at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:135)
    at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
    at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:379)
    at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:233)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:648)
    at org.eclipse.equinox.launcher.Main.basicRun(Main.java:603)
    at org.eclipse.equinox.launcher.Main.run(Main.java:1465)
    at org.eclipse.equinox.launcher.Main.main(Main.java:1438)

 An additional check and the initialization (if needed) were added in order to fix the issue.

Signed-off-by: vrubezhny vrubezhny@exadel.com
