### PR TITLE
Find a way to configure Tern Modules that are default for Nature Adapter...

### DIFF
--- a/core/tern.core/src/tern/TernProject.java
+++ b/core/tern.core/src/tern/TernProject.java
@@ -18,7 +18,6 @@ import java.io.Writer;
 
 import tern.server.ITernDef;
 import tern.server.ITernPlugin;
-import tern.server.TernDef;
 import tern.server.protocol.JsonHelper;
 import tern.utils.IOUtils;
 
@@ -137,7 +136,7 @@ public class TernProject<T> extends JsonObject {
 	 * @param lib
 	 * @return true if the given lib exists and false otherwise.
 	 */
-	public boolean hasLib(TernDef lib) {
+	public boolean hasLib(ITernDef lib) {
 		return hasLib(lib.getName());
 	}
 

--- a/eclipse/tern.eclipse.ide.core/schema/ternNatureAdapters.exsd
+++ b/eclipse/tern.eclipse.ide.core/schema/ternNatureAdapters.exsd
@@ -46,6 +46,9 @@
 
    <element name="ternAdaptToNature">
       <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="defaultModules" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
@@ -61,6 +64,59 @@
             </annotation>
          </attribute>
       </complexType>
+   </element>
+
+   <element name="defaultModules">
+      <annotation>
+         <documentation>
+            Default Tern Modules that are to be loaded for the adapter by default
+         </documentation>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="module" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+      </complexType>
+   </element>
+
+   <element name="module">
+      <annotation>
+         <documentation>
+            Tern Module
+         </documentation>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="0" maxOccurs="unbounded">
+            <element ref="options" minOccurs="0" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="withDependencies" type="boolean">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":tern.eclipse.ide.core.ITernModuleConfigurator"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="options" type="string">
    </element>
 
    <annotation>

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernModuleConfigurator.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernModuleConfigurator.java
@@ -1,0 +1,24 @@
+/**
+ *  Copyright (c) 2014 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+package tern.eclipse.ide.core;
+
+import tern.TernProject;
+
+/**
+ * 
+ * Tern Module External Configurator
+ *
+ */
+public interface ITernModuleConfigurator {
+
+	void configure(TernProject project);
+	
+}


### PR DESCRIPTION
...s defined on a project

A new extension point attribute defined for ternAdaptToNature element in ternNatureAdapters.exsd schema - default modules.
This new attribute allows to specify a comma-separated list of Tern Modules (Libs and Plugins) that are to be loaded by default in Tern Project
in order to provide content assist and validation without a need of manual project configuration.

The source issue: https://issues.jboss.org/browse/JBIDE-17650 - Find better way to enable Tern cordova facet for cordova projects.

Signed-off-by: vrubezhny vrubezhny@exadel.com
