### PR TITLE
Remove target-platform-configuration form tern.repository/pom.xml

### DIFF
--- a/update-site/tern.repository/pom.xml
+++ b/update-site/tern.repository/pom.xml
@@ -16,43 +16,6 @@
 				<version>1.0-beta-6</version>
 			</extension>
 		</extensions>
-			<plugins>
-				<plugin>
-					<groupId>org.eclipse.tycho</groupId>
-					<artifactId>target-platform-configuration</artifactId>
-					<version>${tycho-version}</version>
-					<inherited>true</inherited>
-					<configuration>
-						<environments>
-							<environment>
-								<os>linux</os>
-								<ws>gtk</ws>
-								<arch>x86_64</arch>
-							</environment>
-							<environment>
-								<os>linux</os>
-								<ws>gtk</ws>
-								<arch>x86</arch>
-							</environment>
-							<environment>
-								<os>win32</os>
-								<ws>win32</ws>
-								<arch>x86</arch>
-							</environment>
-							<environment>
-								<os>win32</os>
-								<ws>win32</ws>
-								<arch>x86_64</arch>
-							</environment>
-							<environment>
-								<os>macosx</os>
-								<ws>cocoa</ws>
-								<arch>x86_64</arch>
-							</environment>
-						</environments>
-					</configuration>
-				</plugin>
-			</plugins>
 	</build>
 	<profiles>
 		<!-- This profile is used to upload the repo -->


### PR DESCRIPTION
This target-platform-configuration is already configured in root pom.xml file.
