### PR TITLE
Fix error in TernUIPlugin shutdown

### DIFF
--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/TernUIPlugin.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/TernUIPlugin.java
@@ -49,7 +49,7 @@ public class TernUIPlugin extends AbstractUIPlugin {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext
 	 * )
@@ -60,7 +60,7 @@ public class TernUIPlugin extends AbstractUIPlugin {
 
 		/*
 		 * Display.getDefault().asyncExec(new Runnable() {
-		 * 
+		 *
 		 * public void run() { try { console = new TernConsole(); /* if
 		 * (prefStoreHelper.isOpenIvyConsoleOnStartup()) {
 		 * IvyConsoleFactory.showConsole(); }
@@ -74,20 +74,20 @@ public class TernUIPlugin extends AbstractUIPlugin {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext
 	 * )
 	 */
 	public void stop(BundleContext context) throws Exception {
+		getTernDescriptorManager().destroy();
 		plugin = null;
 		super.stop(context);
-		getTernDescriptorManager().destroy();
 	}
 
 	/**
 	 * Returns the shared instance
-	 * 
+	 *
 	 * @return the shared instance
 	 */
 	public static TernUIPlugin getDefault() {


### PR DESCRIPTION
I'm getting the following error when tern.eclipse.ide.ui bundle shuts down.  This PR contains a simple fix.

```
org.osgi.framework.BundleException: Exception in tern.eclipse.ide.ui.TernUIPlugin.stop() of bundle tern.eclipse.ide.ui.
    at org.eclipse.osgi.internal.framework.BundleContextImpl.stop(BundleContextImpl.java:847)
    at org.eclipse.osgi.internal.framework.EquinoxBundle.stopWorker0(EquinoxBundle.java:950)
    at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.stopWorker(EquinoxBundle.java:324)
    at org.eclipse.osgi.container.Module.doStop(Module.java:626)
    at org.eclipse.osgi.container.Module.stop(Module.java:488)
    at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.decStartLevel(ModuleContainer.java:1623)
    at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1542)
    at org.eclipse.osgi.container.SystemModule.stopWorker(SystemModule.java:248)
    at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule.stopWorker(EquinoxBundle.java:145)
    at org.eclipse.osgi.container.Module.doStop(Module.java:626)
    at org.eclipse.osgi.container.Module.stop(Module.java:488)
    at org.eclipse.osgi.container.SystemModule.stop(SystemModule.java:186)
    at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule$1.run(EquinoxBundle.java:160)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ExceptionInInitializerError
    at tern.eclipse.ide.ui.TernUIPlugin.getTernDescriptorManager(TernUIPlugin.java:127)
    at tern.eclipse.ide.ui.TernUIPlugin.stop(TernUIPlugin.java:85)
    at org.eclipse.osgi.internal.framework.BundleContextImpl$4.run(BundleContextImpl.java:827)
    at org.eclipse.osgi.internal.framework.BundleContextImpl$4.run(BundleContextImpl.java:1)
    at java.security.AccessController.doPrivileged(Native Method)
    at org.eclipse.osgi.internal.framework.BundleContextImpl.stop(BundleContextImpl.java:820)
    ... 13 more
Caused by: java.lang.NullPointerException
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.getTempDir(TernDescriptorManager.java:237)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.<init>(TernDescriptorManager.java:72)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.<clinit>(TernDescriptorManager.java:52)
    ... 19 more
Root exception:
java.lang.ExceptionInInitializerError
    at tern.eclipse.ide.ui.TernUIPlugin.getTernDescriptorManager(TernUIPlugin.java:127)
    at tern.eclipse.ide.ui.TernUIPlugin.stop(TernUIPlugin.java:85)
    at org.eclipse.osgi.internal.framework.BundleContextImpl$4.run(BundleContextImpl.java:827)
    at org.eclipse.osgi.internal.framework.BundleContextImpl$4.run(BundleContextImpl.java:1)
    at java.security.AccessController.doPrivileged(Native Method)
    at org.eclipse.osgi.internal.framework.BundleContextImpl.stop(BundleContextImpl.java:820)
    at org.eclipse.osgi.internal.framework.EquinoxBundle.stopWorker0(EquinoxBundle.java:950)
    at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.stopWorker(EquinoxBundle.java:324)
    at org.eclipse.osgi.container.Module.doStop(Module.java:626)
    at org.eclipse.osgi.container.Module.stop(Module.java:488)
    at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.decStartLevel(ModuleContainer.java:1623)
    at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1542)
    at org.eclipse.osgi.container.SystemModule.stopWorker(SystemModule.java:248)
    at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule.stopWorker(EquinoxBundle.java:145)
    at org.eclipse.osgi.container.Module.doStop(Module.java:626)
    at org.eclipse.osgi.container.Module.stop(Module.java:488)
    at org.eclipse.osgi.container.SystemModule.stop(SystemModule.java:186)
    at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule$1.run(EquinoxBundle.java:160)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.getTempDir(TernDescriptorManager.java:237)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.<init>(TernDescriptorManager.java:72)
    at tern.eclipse.ide.internal.ui.descriptors.TernDescriptorManager.<clinit>(TernDescriptorManager.java:52)
    ... 19 more
```
