### PR TITLE
NullPointerException occures when openning Properties without a given re...

### DIFF
--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/properties/TernModulesPropertyPage.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/properties/TernModulesPropertyPage.java
@@ -10,6 +10,7 @@
  */
 package tern.eclipse.ide.ui.properties;
 
+import org.eclipse.core.resources.IResource;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -59,7 +60,9 @@ public class TernModulesPropertyPage extends AbstractTernPropertyPage implements
 		parent.setLayout(layout);
 
 		// create UI modules
-		modulesBlock = new TernModulesBlock(getResource().getProject(),
+		IResource resource = getResource();
+		modulesBlock = new TernModulesBlock(
+				resource != null ? resource.getProject() : null,
 				TernUIMessages.TernModulesPropertyPage_desc);
 		modulesBlock.createControl(parent);
 		Control control = modulesBlock.getControl();


### PR DESCRIPTION
...source

an additionan null check is added for the result of getResource() call. The following usages of
the result has such checks, so now it's being checked before the first use.

see: https://issues.jboss.org/browse/JBIDE-18260

Signed-off-by: vrubezhny vrubezhny@exadel.com
