### PR TITLE
Tern Project file is not saved after a plug-in is added

### DIFF
--- a/core/tern.core/src/tern/DirtyableJsonArray.java
+++ b/core/tern.core/src/tern/DirtyableJsonArray.java
@@ -25,6 +25,11 @@ public class DirtyableJsonArray extends JsonArray implements Dirtyable {
 		this.dirtyable = dirtyable;
 	}
 
+	public DirtyableJsonArray(JsonArray source, Dirtyable dirtyable) {
+		super(source);
+		this.dirtyable = dirtyable;
+	}
+	
 	@Override
 	public JsonArray add(String value) {
 		setDirty(true);

--- a/core/tern.core/src/tern/DirtyableJsonObject.java
+++ b/core/tern.core/src/tern/DirtyableJsonObject.java
@@ -26,6 +26,11 @@ public class DirtyableJsonObject extends JsonObject implements Dirtyable {
 		this.dirtyable = dirtyable;
 	}
 
+	public DirtyableJsonObject(JsonObject source, Dirtyable dirtyable) {
+		super(source);
+		this.dirtyable = dirtyable;
+	}
+	
 	@Override
 	public JsonObject add(String name, boolean value) {
 		setDirty(true);

--- a/core/tern.core/src/tern/TernProject.java
+++ b/core/tern.core/src/tern/TernProject.java
@@ -146,9 +146,14 @@ public class TernProject<T> extends DirtyableJsonObject {
 	 */
 	public JsonArray getLibs() {
 		JsonArray libs = (JsonArray) super.get(LIBS_FIELD_NAME);
-		if (libs == null) {
-			libs = new DirtyableJsonArray(this);
-			add(LIBS_FIELD_NAME, libs);
+		if (!(libs instanceof DirtyableJsonArray)) {
+			if (libs == null) {
+				libs = new DirtyableJsonArray(this);
+				add(LIBS_FIELD_NAME, libs);
+			} else {
+				libs = new DirtyableJsonArray(libs, this);
+				set(LIBS_FIELD_NAME, libs);
+			}
 		}
 		return libs;
 	}
@@ -204,9 +209,14 @@ public class TernProject<T> extends DirtyableJsonObject {
 	 */
 	public JsonObject getPlugins() {
 		JsonObject plugins = (JsonObject) super.get(PLUGINS_FIELD_NAME);
-		if (plugins == null) {
-			plugins = new DirtyableJsonObject(this);
-			add(PLUGINS_FIELD_NAME, plugins);
+		if (!(plugins instanceof DirtyableJsonObject)) {
+			if (plugins == null) {
+				plugins = new DirtyableJsonObject(this);
+				add(PLUGINS_FIELD_NAME, plugins);
+			} else {
+				plugins = new DirtyableJsonObject(plugins, this);
+				set(PLUGINS_FIELD_NAME, plugins);
+			}
 		}
 		return plugins;
 	}


### PR DESCRIPTION
When configuring an existing Tern Project and we have to add some plug-in to that project,
it's not marked as a 'dirty' project, so the new .tern-project file is not saved.
As result the newly added plugin is not working (in Content Assist and validation) and the
following exceptions appear in the error log:

!ENTRY org.eclipse.angularjs.core 4 0 2014-09-18 00:45:29.697
!MESSAGE Error while tern validator.
!STACK 0
tern.TernException: tern.TernException: No query type 'angular' defined
    at tern.server.nodejs.NodejsTernServer.request(NodejsTernServer.java:315)
    at tern.eclipse.ide.core.IDETernProject.request(IDETernProject.java:729)
    at tern.eclipse.ide.core.IDETernProject.request(IDETernProject.java:710)
    at org.eclipse.angularjs.core.validation.ValidatorUtils.isAngularElementExists(ValidatorUtils.java:244)
    at org.eclipse.angularjs.core.validation.ValidatorUtils.validate(ValidatorUtils.java:188)
    at org.eclipse.angularjs.ui.validation.HTMLAngularContentValidator.doValidate(HTMLAngularContentValidator.java:26)
    at org.eclipse.angularjs.internal.ui.validation.AbstractValidator.validate(AbstractValidator.java:152)
    at org.eclipse.angularjs.internal.ui.validation.AbstractValidator.validate(AbstractValidator.java:134)
    at org.eclipse.angularjs.internal.ui.validation.AbstractValidator.validate(AbstractValidator.java:118)
    at org.eclipse.wst.sse.ui.internal.reconcile.validator.ReconcileStepForValidator.validate(ReconcileStepForValidator.java:381)
    at org.eclipse.wst.sse.ui.internal.reconcile.validator.ReconcileStepForValidator.reconcileModel(ReconcileStepForValidator.java:259)
    at org.eclipse.jface.text.reconciler.AbstractReconcileStep.reconcile(AbstractReconcileStep.java:95)
    at org.eclipse.wst.sse.ui.internal.reconcile.validator.ValidatorStrategy.reconcile(ValidatorStrategy.java:269)
    at org.eclipse.wst.sse.ui.internal.reconcile.DocumentRegionProcessor.process(DocumentRegionProcessor.java:321)
    at org.eclipse.wst.sse.ui.internal.reconcile.StructuredRegionProcessor.process(StructuredRegionProcessor.java:258)
    at org.eclipse.wst.sse.ui.internal.reconcile.DirtyRegionProcessor$BackgroundThread.run(DirtyRegionProcessor.java:691)
Caused by: tern.TernException: No query type 'angular' defined
    at tern.server.nodejs.NodejsTernHelper.makeRequest(NodejsTernHelper.java:87)
    at tern.server.nodejs.NodejsTernServer.makeRequest(NodejsTernServer.java:170)
    at tern.server.nodejs.NodejsTernServer.request(NodejsTernServer.java:301)
    ... 15 more

Signed-off-by: vrubezhny vrubezhny@exadel.com
