### PR TITLE
Add ITernFileHelper extension point 

### DIFF
--- a/core/tern.core.tests/src/tern/server/protocol/HtmlHelperTest.java
+++ b/core/tern.core.tests/src/tern/server/protocol/HtmlHelperTest.java
@@ -8,9 +8,21 @@ public class HtmlHelperTest {
 	@Test
 	public void replaceWhitespace() {
 
+		String[] tags = new String[] {"script"};
 		String html = HtmlHelper
-				 .extractJS("<html>\nvar a = '';<script>var a = [];</script>  <script>var b = [];</script></html>");
+				.extractJS("<html>\nvar a = '';<script>var a = [];</script>  <script>var b = [];</script></html>", tags);
 		Assert.assertEquals("      \n                   var a = [];                   var b = [];                ",
+				html);
+
+	}
+
+	@Test
+	public void alternateTags() {
+
+		String[] tags = new String[] {"script", "aui:script"};
+		String html = HtmlHelper
+				 .extractJS("<html>\nvar a = '';<script>var a = [];</script>  <aui:script>var b = [];</aui:script></html>", tags);
+		Assert.assertEquals("      \n                   var a = [];                       var b = [];                    ",
 				html);
 
 	}

--- a/core/tern.core/src/tern/server/protocol/HtmlHelper.java
+++ b/core/tern.core/src/tern/server/protocol/HtmlHelper.java
@@ -1,15 +1,31 @@
 package tern.server.protocol;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class HtmlHelper {
 
 	private enum Result {
 		MATCHING, NO_MATCHING, MATCHED
 	}
 
-	private enum Region {
+	private enum RegionType {
+		OPEN_START_SCRIPT, CLOSE_START_SCRIPT, END_SCRIPT
+	}
 
-		OPEN_START_SCRIPT("<script"), CLOSE_START_SCRIPT(">"), END_SCRIPT(
-				"</script>");
+	private static class TagRegion {
+		private final Region openStart;
+		private final Region closeStart;
+		private final Region end;
+
+		TagRegion(String tag) {
+			this.openStart = new Region("<" + tag);
+			this.closeStart = new Region(">");
+			this.end = new Region("</" + tag + ">");
+		}
+	}
+
+	private static class Region {
 
 		private final char[] pattern;
 
@@ -27,12 +43,22 @@ public class HtmlHelper {
 
 			return Result.NO_MATCHING;
 		}
+
+		int length() {
+			return this.pattern.length;
+		}
 	}
 
 	protected static class State {
 
+		private final TagRegion tagRegion;
 		private int index = 0;
-		private Region region = Region.OPEN_START_SCRIPT;
+		private Region region;//= Region.OPEN_START_SCRIPT;
+
+		protected State(TagRegion tagRegion) {
+			this.tagRegion = tagRegion;
+			region = tagRegion.openStart;
+		}
 
 		public Region add(char c) {
 			Result result = region.search(c, index);
@@ -45,21 +71,23 @@ public class HtmlHelper {
 				break;
 			case MATCHED:
 				index = 0;
-				switch (region) {
+				switch (getRegionType(region)) {
 				case OPEN_START_SCRIPT:
-					region = Region.CLOSE_START_SCRIPT;
-					return Region.OPEN_START_SCRIPT;
+					region = tagRegion.closeStart;
+					return tagRegion.openStart;
 				case CLOSE_START_SCRIPT:
-					region = Region.END_SCRIPT;
-					return Region.CLOSE_START_SCRIPT;
+					region = tagRegion.end;
+					return tagRegion.closeStart;
 				case END_SCRIPT:
-					region = Region.OPEN_START_SCRIPT;
-					return Region.END_SCRIPT;
+					region = tagRegion.openStart;
+					return tagRegion.end;
 				}
 				break;
 			}
 			return null;
 		}
+
+
 
 		public Region getRegion() {
 			return region;
@@ -67,37 +95,89 @@ public class HtmlHelper {
 
 	}
 
-	public static String extractJS(String html) {
-		State state = new State();
-		StringBuilder s = new StringBuilder();
-		char[] chars = html.toCharArray();
-		for (int i = 0; i < chars.length; i++) {
-			char c = chars[i];
-			switch (c) {
-			case '\n':
-			case '\r':
-			case '\t':
-			case ' ':
-				s.append(c);
-				break;
-			default:
-				Region matchedRegion = state.add(c);
-				if (matchedRegion == null) {
-					if (state.getRegion().equals(Region.END_SCRIPT)) {
-						s.append(c);
+	public static String extractJS(String html, String[] tags) {
+		//multiple passes
+		List<String> passes = new ArrayList<String>();
+		for (String tag : tags) {
+			State state = new State(new TagRegion(tag));
+			StringBuilder s = new StringBuilder();
+			char[] chars = html.toCharArray();
+			for (int i = 0; i < chars.length; i++) {
+				char c = chars[i];
+				switch (c) {
+				case '\n':
+				case '\r':
+				case '\t':
+				case ' ':
+					s.append(c);
+					break;
+				default:
+					Region matchedRegion = state.add(c);
+					if (matchedRegion == null) {
+						if (state.getRegion().equals(state.tagRegion.end)) {
+							s.append(c);
+						} else {
+							s.append(' ');
+						}
 					} else {
+						if (matchedRegion.equals(state.tagRegion.end)) {
+							s = s.replace(i - matchedRegion.length()+1, i, pad(matchedRegion.length()-1));
+						}
 						s.append(' ');
 					}
-				} else {
-					if (matchedRegion.equals(Region.END_SCRIPT)) {
-						s = s.replace(i - 8, i, "        ");
-					}
-					s.append(' ');
 				}
+			}
+
+			passes.add(s.toString());
+		}
+
+		return merge(passes);
+	}
+
+	private static RegionType getRegionType(Region region) {
+		RegionType retval = null;
+
+		final String pattern = new String(region.pattern);
+
+		if (pattern.contains("</")) {
+			retval = RegionType.END_SCRIPT;
+		}
+		else if (pattern.contains(">")) {
+			retval = RegionType.CLOSE_START_SCRIPT;
+		}
+		else if (pattern.contains("<")) {
+			retval = RegionType.OPEN_START_SCRIPT;
+		}
+
+		return retval;
+	}
+
+
+	private static String pad(int length) {
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < length; i++) {
+			sb.append(" ");
+		}
+
+		return sb.toString();
+	}
+
+	private static String merge(List<String> passes) {
+		int size = -1;
+		for (String pass : passes) {
+			size = Math.max(size, pass.length());
+		}
+
+		char[] merged = new char[size];
+
+		for (int i = 0; i < merged.length; i++) {
+			for (String pass: passes) {
+				merged[i] = (char) Math.max(merged[i], pass.toCharArray()[i]);
 			}
 		}
 
-		return s.toString();
+		return new String(merged);
 	}
 
 }

--- a/core/tern.core/src/tern/server/protocol/TernDoc.java
+++ b/core/tern.core/src/tern/server/protocol/TernDoc.java
@@ -75,7 +75,11 @@ public class TernDoc extends JsonObject {
 	 *            null if "full" file type and "part" otherwise.
 	 */
 	public void addFile(String name, String text, boolean isHTML, Integer offset) {
-		addFile(new TernFile(name, text, isHTML, offset));
+		addFile(new TernFile(name, text, isHTML, offset, new String[] {"script"}));
+	}
+
+	public void addFile(String name, String text, boolean isHTML, Integer offset, String[] tags) {
+		addFile(new TernFile(name, text, isHTML, offset, tags));
 	}
 
 	/**

--- a/core/tern.core/src/tern/server/protocol/TernFile.java
+++ b/core/tern.core/src/tern/server/protocol/TernFile.java
@@ -31,9 +31,9 @@ public class TernFile extends JsonObject {
 		part, full
 	}
 
-	public TernFile(String name, String text, boolean isHTML, Integer offset) {
+	public TernFile(String name, String text, boolean isHTML, Integer offset, String[] tags) {
 		super.add(NAME_FIELD_NAME, name);
-		super.add(TEXT_FIELD_NAME, getText(text, isHTML));
+		super.add(TEXT_FIELD_NAME, getText(text, isHTML, tags));
 		if (offset != null) {
 			super.add(TYPE_FIELD_NAME, FileType.part.name());
 			super.add(OFFSET_LINES_FIELD_TYPE, offset);
@@ -42,11 +42,11 @@ public class TernFile extends JsonObject {
 		}
 	}
 
-	private String getText(String text, boolean isHTML) {
+	private String getText(String text, boolean isHTML, String[] tags) {
 		if (text == null || !isHTML) {
 			return text;
 		}
-		return HtmlHelper.extractJS(text);
+		return HtmlHelper.extractJS(text, tags);
 	}
 
 	public String getName() {

--- a/eclipse/tern.eclipse.ide.core/plugin.properties
+++ b/eclipse/tern.eclipse.ide.core/plugin.properties
@@ -6,13 +6,14 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#     Angelo Zerr <angelo.zerr@gmail.com> - Initial API and implementation 
+#     Angelo Zerr <angelo.zerr@gmail.com> - Initial API and implementation
 ###############################################################################
 pluginName=Tern - Eclipse - Core IDE
 providerName=Angelo ZERR
 
 # Extension point
 ternServerTypes.name=Tern Server Types.
+ternFileHelpers.name=Tern File Helpers.
 ternConsoleConnectors.name=Tern Console Connectors.
 ternNatureAdapters.name=Tern Nature Adapters
 

--- a/eclipse/tern.eclipse.ide.core/plugin.xml
+++ b/eclipse/tern.eclipse.ide.core/plugin.xml
@@ -15,9 +15,11 @@
 <plugin>
 	
 	<extension-point id="ternServerTypes" name="%ternServerTypes.name"
-		schema="schema/ternServerTypes.exsd" />	
+		schema="schema/ternServerTypes.exsd" />
+	<extension-point id="ternFileHelpers" name="%ternFileHelpers.name"
+		schema="schema/ternFileHelpers.exsd" />
 	<extension-point id="ternConsoleConnectors" name="%ternConsoleConnectors.name"
-		schema="schema/ternConsoleConnectors.exsd" />	
+		schema="schema/ternConsoleConnectors.exsd" />
 	<extension-point id="ternNatureAdapters" name="%ternNatureAdapters.name"
 		schema="schema/ternNatureAdapters.exsd" />	
 	

--- a/eclipse/tern.eclipse.ide.core/schema/ternFileHelpers.exsd
+++ b/eclipse/tern.eclipse.ide.core/schema/ternFileHelpers.exsd
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="tern.eclipse.ide.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="tern.eclipse.ide.core" id="ternFileHelpers" name="tern File Helpers"/>
+      </appInfo>
+      <documentation>
+         Extension point for provide Tern File Helpers.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="fileHelper" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  a fully-qualified name of the target extension point
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  an optional id
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  an optional name
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="fileHelper">
+      <complexType>
+         <sequence>
+         </sequence>
+         <attribute name="extraTags" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         2.0
+      </documentation>
+   </annotation>
+
+
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         This plugin itself does not have any predefined builders.
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernFileHelper.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernFileHelper.java
@@ -1,0 +1,18 @@
+/**
+ *  Copyright (c) 2013-2014 Liferay, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Gregory Amerson <gregory.amerson@liferay.com> - initial API and implementation
+ */
+package tern.eclipse.ide.core;
+
+
+public interface ITernFileHelper {
+
+	String getExtraTags();
+
+}

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernFileHelperManager.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernFileHelperManager.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2013-2014 Liferay, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Gregory Amerson <gregory.amerson@liferay.com> - initial API and implementation
+ */
+package tern.eclipse.ide.core;
+
+
+/**
+ * Tern file helper manager API.
+ *
+ */
+public interface ITernFileHelperManager {
+
+	/**
+	 * Returns an array of all tern file helpers
+	 * <p>
+	 * A new array is returned on each call, so clients may store or modify the
+	 * result.
+	 * </p>
+	 *
+	 * @return the array of tern file helpers {@link ITernFileHelper}
+	 */
+	ITernFileHelper[] getTernFileHelpers();
+
+}

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/IDETernProject.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/IDETernProject.java
@@ -10,12 +10,18 @@
  */
 package tern.eclipse.ide.internal.core;
 
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -35,6 +41,7 @@ import tern.angular.protocol.completions.TernAngularCompletionsQuery;
 import tern.eclipse.ide.core.IDETernFileManager;
 import tern.eclipse.ide.core.IIDETernProject;
 import tern.eclipse.ide.core.ITernConsoleConnector;
+import tern.eclipse.ide.core.ITernFileHelper;
 import tern.eclipse.ide.core.ITernProjectLifecycleListener.LifecycleEventType;
 import tern.eclipse.ide.core.ITernServerPreferencesListener;
 import tern.eclipse.ide.core.ITernServerType;
@@ -61,8 +68,6 @@ import tern.server.protocol.definition.ITernDefinitionCollector;
 import tern.server.protocol.lint.ITernLintCollector;
 import tern.server.protocol.type.ITernTypeCollector;
 
-import com.eclipsesource.json.JsonArray;
-import com.eclipsesource.json.JsonObject;
 
 /**
  * Eclipse IDE Tern project.
@@ -681,7 +686,14 @@ public class IDETernProject extends TernProject<IFile> implements
 				String name = getFileManager().getFileName(file);
 				String text = document.get();
 				boolean isHTML = FileUtils.isHTMLFile(file);
-				doc.addFile(name, text, isHTML, null);
+				ITernFileHelper[] ternFileHelpers =
+					TernFileHelperManager.getManager().getTernFileHelpers();
+				Set<String> tags = new HashSet<String>();
+				tags.add( "script" );
+				for( ITernFileHelper helper : ternFileHelpers ) {
+					Collections.addAll( tags, helper.getExtraTags().split(",") );
+				}
+				doc.addFile(name, text, isHTML, null, tags.toArray( new String[0] ));
 				TernQuery query = doc.getQuery();
 				if (query != null) {
 					query.setFile(name);

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernFileHelper.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernFileHelper.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2013-2014 Liferay, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Gregory Amerson <gregory.amerson@liferay.com> - initial API and implementation
+ */
+package tern.eclipse.ide.internal.core;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+
+import tern.eclipse.ide.core.ITernFileHelper;
+
+public class TernFileHelper implements ITernFileHelper {
+
+	private final String extraTags;
+
+	public TernFileHelper(IConfigurationElement element) throws CoreException {
+		this.extraTags = element.getAttribute("extraTags");
+	}
+
+	@Override
+	public String getExtraTags() {
+		return extraTags;
+	}
+
+}

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernFileHelperManager.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernFileHelperManager.java
@@ -1,0 +1,91 @@
+/**
+ *  Copyright (c) 2013-2014 Liferay, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Gregory Amerson <gregory.amerson@liferay.com> - initial API and implementation
+ */
+package tern.eclipse.ide.internal.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
+
+import tern.eclipse.ide.core.ITernFileHelper;
+import tern.eclipse.ide.core.ITernFileHelperManager;
+import tern.eclipse.ide.core.TernCorePlugin;
+
+/**
+ * Manager of tern file helpers loaded by the extension point "ternFileHelpers"
+ *
+ */
+public class TernFileHelperManager implements ITernFileHelperManager
+{
+
+	private static final String EXTENSION_TERN_FILE_HELPERS = "ternFileHelpers";
+
+	private static final TernFileHelperManager INSTANCE = new TernFileHelperManager();
+
+	// cached copy of all tern file helpers
+	private List<ITernFileHelper> ternFileHelpers;
+
+	public static TernFileHelperManager getManager() {
+		return INSTANCE;
+	}
+
+	public TernFileHelperManager() {
+	}
+
+	@Override
+	public ITernFileHelper[] getTernFileHelpers() {
+		if (ternFileHelpers == null)
+			loadTernFileHelpers();
+
+		ITernFileHelper[] fh = new ITernFileHelper[ternFileHelpers.size()];
+		ternFileHelpers.toArray(fh);
+		return fh;
+	}
+
+	/**
+	 * Load the tern file helpers
+	 */
+	private synchronized void loadTernFileHelpers() {
+		if (ternFileHelpers != null)
+			return;
+
+		Trace.trace(Trace.EXTENSION_POINT,
+				"->- Loading .ternFileHelpers extension point ->-");
+
+		IExtensionRegistry registry = Platform.getExtensionRegistry();
+		IConfigurationElement[] cf = registry.getConfigurationElementsFor(
+				TernCorePlugin.PLUGIN_ID, EXTENSION_TERN_FILE_HELPERS);
+		List<ITernFileHelper> list = new ArrayList<ITernFileHelper>(cf.length);
+		addTernFileHelpers(cf, list);
+		ternFileHelpers = list;
+
+		Trace.trace(Trace.EXTENSION_POINT,
+				"-<- Done loading .ternFileHelpers extension point -<-");
+	}
+
+	/**
+	 * Load the tern file helpers
+	 */
+	private synchronized void addTernFileHelpers(IConfigurationElement[] cf,
+			List<ITernFileHelper> list) {
+		for (IConfigurationElement ce : cf) {
+			try {
+				list.add(new TernFileHelper(ce));
+			} catch (Throwable t) {
+				Trace.trace(
+						Trace.SEVERE, "  Could not load file helper", t);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
This extension point allows adopters to specify multiple tags to be searched in the TernFile when building the javascript text to send to the tern server.

This will be extended in Liferay IDE like this:

```
<extension
          point="tern.eclipse.ide.core.ternFileHelpers">
       <fileHelper
             extraTags="aui:script">
       </fileHelper>
</extension>
```
