### PR TITLE
README for core

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,2 @@
+All classes from here must be NOT linked to Eclipse classes. 
+Indead those classes could be used for other IDE (Intellij, Netbeans, etc).


### PR DESCRIPTION
as @angelozerr said in #149

> The only thing I would like to keep is that all classes from https://github.com/angelozerr/tern.java/tree/master/core must be NOT linked to Eclipse classes. Indead those classes could be used for other IDE (Intellij, Netbeans, etc).
