### PR TITLE
Names of "Server Plugin" and "JSON type definition" Wizards are bit conf...

### DIFF
--- a/eclipse/tern.eclipse.ide.tools.ui/plugin.properties
+++ b/eclipse/tern.eclipse.ide.tools.ui/plugin.properties
@@ -13,8 +13,8 @@ providerName=Angelo ZERR
 
 # Wizard
 TernWizard.name=Tern
-NewTernDefWizard.name=JSON type definition
-NewTernPluginWizard.name=Server Plugin
+NewTernDefWizard.name=Tern JSON type definition
+NewTernPluginWizard.name=Tern Server Plugin
 WebBrowserWizard.name= Web Browser
 NewCodeMirrorWizard.name=CodeMirror
 NewAceWizard.name=Ace


### PR DESCRIPTION
...using for users.

When a user opens "New -> Other..." wizard and types in the word "server" as a filter, (s)he gets
"Server Plugin" wizard under "Tern" category. But in context of JBoss Tools users, for instance,
it's not for an end user. This wizard is  more for the tooling developer. JBT users shouldn't care
of the fact that Tern is run under some server. They use "server" term for WhildFly, EAP and so on.

So, having the "Server Plugin" wizard shown when searching by "server" keyword is a bit confusing thing.

The same goes for "type" word - it shows "JSON type definition" wizard. Which is not the most interesting
part of the Tooling for an end user.

Since both the wizards are registered correctly and I see no problems with these wizards other than their "a bit confusing"
appearance, I'd like to rename them to "Tern Server Plugin" and "Tern JSON type definition" due to make the names:
- not to confuse users;
- to mark the wizards as some Tern specific things.

Also, after such a rename, if a user will type in "tern" as a filter, (s)he will be proposed with both the wizards.

Signed-off-by: vrubezhny vrubezhny@exadel.com
