### PR TITLE
Fix for issue #240 and issue #237

### DIFF
--- a/core/tern.core/src/tern/ITernFileSynchronizer.java
+++ b/core/tern.core/src/tern/ITernFileSynchronizer.java
@@ -72,14 +72,14 @@ public interface ITernFileSynchronizer {
 	public void synchronizeScriptPath(ITernScriptPath path, String... forced);
 
 	/**
-	 * Notifies cache manager that files has been successfully uploaded. This
-	 * method should be called by tern server if the tern response doesn't
-	 * throws error.
+	 * Notifies cache manager that files has not been successfully uploaded.
+	 * This method should be called by tern file uploader or tern server in case
+	 * upload fails.
 	 * 
 	 * @param doc
 	 *            the tern doc.
 	 */
-	public void filesUploaded(TernDoc doc);
+	public void uploadFailed(TernDoc doc);
 
 	/**
 	 * Cleans all cache information. Next call to ensureSynchronized will

--- a/core/tern.core/src/tern/resources/SynchronousTernFileUploader.java
+++ b/core/tern.core/src/tern/resources/SynchronousTernFileUploader.java
@@ -17,16 +17,16 @@ import tern.server.ITernServer;
 import tern.server.protocol.TernDoc;
 
 /**
- * Basic synchronous file uploader. * 
+ * Basic synchronous file uploader. *
  */
 public class SynchronousTernFileUploader implements ITernFileUploader {
-	
+
 	private ITernProject project;
-	
+
 	public SynchronousTernFileUploader(ITernProject project) {
 		this.project = project;
 	}
-	
+
 	@Override
 	public boolean cancel(String fileName) {
 		return false;
@@ -45,6 +45,7 @@ public class SynchronousTernFileUploader implements ITernFileUploader {
 				@Override
 				public void onError(String error, Throwable t) {
 					project.handleException(new TernException(error, t));
+					project.getFileSynchronizer().uploadFailed(doc);
 				}
 
 				@Override
@@ -54,11 +55,10 @@ public class SynchronousTernFileUploader implements ITernFileUploader {
 			});
 		}
 
-		
 	}
 
 	@Override
 	public void join(long timeout) {
-		//always up-to-date
+		// always up-to-date
 	}
 }

--- a/core/tern.core/src/tern/server/AbstractTernServer.java
+++ b/core/tern.core/src/tern/server/AbstractTernServer.java
@@ -159,11 +159,19 @@ public abstract class AbstractTernServer implements ITernServer {
 	@Override
 	public void request(TernDoc doc, ITernResultsCollector collector)
 			throws TernException {
-		if (reqProcessor == null) {
-			//always provide request processor
-			reqProcessor = new SynchronousRequestProcessor(this);
+		try {
+			if (reqProcessor == null) {
+				// always provide request processor
+				reqProcessor = new SynchronousRequestProcessor(this);
+			}
+			reqProcessor.processRequest(doc, collector);
+		} catch (Exception e) {
+			getFileSynchronizer().uploadFailed(doc);
+			if (e instanceof TernException) {
+				throw (TernException) e;
+			}
+			throw new TernException(e);
 		}
-		reqProcessor.processRequest(doc, collector);
 	}
 
 	@Override
@@ -172,8 +180,7 @@ public abstract class AbstractTernServer implements ITernServer {
 	}
 
 	@Override
-	public void setRequestProcessor(
-			ITernServerRequestProcessor reqProcessor) {
+	public void setRequestProcessor(ITernServerRequestProcessor reqProcessor) {
 		this.reqProcessor = reqProcessor;
 	}
 

--- a/core/tern.server.nodejs/src/tern/server/nodejs/NodejsTernHelper.java
+++ b/core/tern.server.nodejs/src/tern/server/nodejs/NodejsTernHelper.java
@@ -96,11 +96,6 @@ public class NodejsTernHelper {
 								methodName, getElapsedTimeInMs(startTime));
 					}
 				}
-				// Update file synchronizer if needed.
-				ITernFileSynchronizer fileSynchronizer = server.getFileSynchronizer();
-				if (fileSynchronizer != null) {
-					fileSynchronizer.filesUploaded(doc);
-				}
 				return response;
 			} catch (ParseException e) {
 				throw new IOException(e);

--- a/core/tern.server.rhino/src/tern/server/rhino/RhinoTernServer.java
+++ b/core/tern.server.rhino/src/tern/server/rhino/RhinoTernServer.java
@@ -206,14 +206,6 @@ public class RhinoTernServer extends AbstractTernServer {
 			Object fObj = ternScope.get("request2", ternScope);
 			Function f = (Function) fObj;
 			f.call(cx, ternScope, ternScope, functionArgs);
-
-			// Update file manager if needed.
-			ITernFileSynchronizer fileSynchronizer = super
-					.getFileSynchronizer();
-			if (fileSynchronizer != null) {
-				fileSynchronizer.filesUploaded(doc);
-			}
-
 		} finally {
 			// Exit from the context.
 			Context.exit();

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/resources/IDETernProject.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/resources/IDETernProject.java
@@ -47,6 +47,7 @@ import tern.eclipse.ide.internal.core.builder.TernBuilder;
 import tern.eclipse.ide.internal.core.preferences.TernCorePreferencesSupport;
 import tern.eclipse.ide.internal.core.scriptpath.FolderScriptPath;
 import tern.repository.ITernRepository;
+import tern.resources.TernFileSynchronizer;
 import tern.resources.TernProject;
 import tern.scriptpath.ITernScriptPath;
 import tern.scriptpath.ITernScriptPath.ScriptPathsType;
@@ -533,6 +534,10 @@ public class IDETernProject extends TernProject implements IIDETernProject,
 		synchronized (serverLock) {
 			if (!isServerDisposed()) {
 				if (ternServer != null) {
+					// notify uploader that we are going to dispose the server,
+					// so that it can finish gracefully
+					((IDETernFileUploader) ((TernFileSynchronizer) getFileSynchronizer())
+							.getTernFileUploader()).serverToBeDisposed();
 					ternServer.dispose();
 					ternServer = null;
 				}


### PR DESCRIPTION
Instead of repeating the request every time the server is disposed, which can lead to infinite loop, upload job is being notified when server is being disposed gracefully and can finish cleanly. Additionally, if server object changes, file synchronizer index is being cleaned.