### PR TITLE
Perhaps as a result of some refactoring, the eclipse's .project files ar...

### DIFF
--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.core/.project
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.core/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>tern.eclipse.ide.jsdt</name>
+	<name>tern.eclipse.ide.jsdt.core</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/.project
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>tern.eclipse.ide.jsdt</name>
+	<name>tern.eclipse.ide.jsdt.ui</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
...e became equal for tern.eclipse.ide.jsdt.core and

tern.eclipse.ide.jsdt.ui projects. As result, I cannot import them both at the same time into an eclipse workspace.

The fix assignes the correct names for the projects listed above

Signed-off-by: vrubezhny <vrubezhny@exadel.com>