### PR TITLE
tern.eclipse.ide.linter.ui has wrong name in its .project file

### DIFF
--- a/eclipse/linters/tern.eclipse.ide.linter.ui/.project
+++ b/eclipse/linters/tern.eclipse.ide.linter.ui/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>tern.eclipse.ide.linters.jshint.ui</name>
+	<name>tern.eclipse.ide.linters.ui</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
This prevents the plug-in to be imported into an Eclipse Workspace along with
tern.eclipse.ide.linter.jshint.ui plug-in

Signed-off-by: vrubezhny <vrubezhny@exadel.com>