### PR TITLE
NPE in EditorUtils.getFile(EditorUtils.java:135)

### DIFF
--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/EditorUtils.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/EditorUtils.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2013-2014 Angelo ZERR.
+ *  Copyright (c) 2013-2015 Angelo ZERR.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -128,8 +128,12 @@ public class EditorUtils {
 	public static IFile getFile(IDocument document) {
 		ITextFileBufferManager bufferManager = FileBuffers
 				.getTextFileBufferManager(); // get the buffer manager
-		IPath location = bufferManager.getTextFileBuffer(document)
-				.getLocation();
+		ITextFileBuffer buffer = bufferManager.getTextFileBuffer(document);
+		IPath location = buffer == null ? null : buffer.getLocation();
+		if (location == null) {
+			return null;
+		}
+		
 		return ResourcesPlugin.getWorkspace().getRoot().getFile(location);
 	}
 


### PR DESCRIPTION
This is a fix for the following exception:

!ENTRY org.eclipse.jface.text 4 0 2015-06-30 10:51:13.096
!MESSAGE Unexpected runtime error while computing a text hover
!STACK 0
java.lang.NullPointerException
	at tern.eclipse.ide.ui.utils.EditorUtils.getFile(EditorUtils.java:135)
	at tern.eclipse.ide.ui.hover.TernHover.getFile(TernHover.java:93)
	at tern.eclipse.ide.ui.hover.TernHover.getHoverInfo2(TernHover.java:58)
	at tern.eclipse.ide.ui.hover.TernHover.getHoverInfo(TernHover.java:48)
	at org.eclipse.wst.jsdt.internal.ui.text.java.hover.BestMatchHover.getHoverInfo(BestMatchHover.java:99)
	at org.eclipse.wst.jsdt.internal.ui.text.java.hover.JavaEditorTextHoverProxy.getHoverInfo(JavaEditorTextHoverProxy.java:67)
	at org.eclipse.jface.text.TextViewerHoverManager$4.run(TextViewerHoverManager.java:168)

Signed-off-by: vrubezhny <vrubezhny@exadel.com>