### PR TITLE
Make Outline rely more and more on common navigator framework

### DIFF
--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.core/plugin.xml
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.core/plugin.xml
@@ -22,5 +22,15 @@
 	         name="JSDT Class Path Manager Provider">
 	   </provider>
 	</extension>
+ <extension
+       point="org.eclipse.core.runtime.adapters">
+    <factory
+          adaptableType="org.eclipse.wst.jsdt.core.IJavaScriptProject"
+          class="tern.eclipse.ide.jsdt.internal.core.JSDTToTernAdapter">
+       <adapter
+             type="tern.eclipse.ide.core.IIDETernProject">
+       </adapter>
+    </factory>
+ </extension>
 
 </plugin>        

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.core/src/tern/eclipse/ide/jsdt/internal/core/JSDTToTernAdapter.java
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.core/src/tern/eclipse/ide/jsdt/internal/core/JSDTToTernAdapter.java
@@ -1,0 +1,75 @@
+/**
+ *  Copyright (c) 2015 Red Hat Inc. and others
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *    Mickael Istria (Red Hat Inc.)
+ */
+package tern.eclipse.ide.jsdt.internal.core;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdapterFactory;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.wst.jsdt.core.IJavaScriptProject;
+import org.eclipse.wst.jsdt.core.IJavaScriptUnit;
+
+import tern.ITernFile;
+import tern.ITernProject;
+import tern.TernResourcesManager;
+import tern.eclipse.ide.core.TernCorePlugin;
+import tern.eclipse.ide.core.resources.TernDocumentFile;
+
+public class JSDTToTernAdapter implements IAdapterFactory {
+
+	@Override
+	public Object getAdapter(Object adaptableObject, Class/*<T>*/ adapterType) {
+	//public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+		try {
+			if (ITernProject.class.equals(adapterType)) {
+				IProject project = null;
+				if (adaptableObject instanceof IProject) {
+					project = (IProject) adaptableObject;
+				} else if (adaptableObject instanceof IJavaScriptProject) {
+					project = ((IJavaScriptProject)adaptableObject).getProject();
+				}
+				if (project != null) {
+					return /*(T)*/ TernCorePlugin.getTernProject(((IJavaScriptProject)adaptableObject).getProject());
+				}
+			}
+			
+			if (ITernFile.class.equals(adapterType)) {
+				IResource resource = null;
+				if (adaptableObject instanceof IFile) {
+					resource = (IFile)adaptableObject;
+				} else if (adaptableObject instanceof IJavaScriptUnit) {
+					IJavaScriptUnit unit = (IJavaScriptUnit)adaptableObject;
+				}
+				if (resource != null) {
+					return /*(T)*/ TernCorePlugin.getTernProject(resource.getProject()).getFile(resource.getProjectRelativePath().toString());
+				}
+			}
+		} catch (CoreException ex) {
+			JSDTTernCorePlugin.getDefault().getLog().log(new Status(
+					IStatus.ERROR,
+					JSDTTernCorePlugin.getDefault().getBundle().getSymbolicName(),
+					ex.getMessage(),
+					ex));
+		}
+		
+		return null;
+	}
+
+	@Override
+	public Class<?>[] getAdapterList() {
+		return new Class<?>[] { ITernProject.class, ITernFile.class };
+	}
+
+}

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/META-INF/MANIFEST.MF
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/META-INF/MANIFEST.MF
@@ -22,7 +22,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.sse.ui,
  org.eclipse.wst.xml.ui,
  tern.eclipse.ide.jsdt.core,
- org.eclipse.search
+ org.eclipse.search,
+ org.eclipse.ui.navigator,
+ org.eclipse.ui.ide
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tern.eclipse.ide.jsdt.internal.ui.JSDTTernUIPlugin
 Import-Package: com.eclipsesource.json;version="[0.9.4,0.9.5)"

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/plugin.properties
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/plugin.properties
@@ -19,3 +19,5 @@ ternHoverDescription= Tern Hover
 
 # Hyperlink
 ternHyperLinkDetector=Tern JavaScript Element
+jsdtElementFilter=Filter JSDT elements when Tern found a matching entry
+jsdtElementFilter_desc=Remove JSDT elements from tree (outline) if Tern shows similar ones

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/plugin.xml
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/plugin.xml
@@ -154,5 +154,57 @@
 	       point="org.eclipse.ui.startup">	
 	       <startup class="tern.eclipse.ide.jsdt.internal.ui.JSDTTernStartup" />       
 	 </extension>
+      
+     <extension
+         point="org.eclipse.ui.navigator.linkHelper">
+      <linkHelper
+            class="tern.eclipse.ide.jsdt.internal.ui.JSDTTernLinkHelper"
+            id="tern.eclipse.ide.jsdt.ui.linkHelper">
+         <editorInputEnablement>
+            <instanceof
+                  value="java.lang.Object">
+            </instanceof></editorInputEnablement>
+         <selectionEnablement>
+            <instanceof
+                  value="java.lang.Object">
+            </instanceof>
+         </selectionEnablement>
+      </linkHelper>
+   </extension>
+   <extension
+       point="org.eclipse.ui.navigator.navigatorContent">
+      <commonFilter
+          activeByDefault="true"
+          class="tern.eclipse.ide.jsdt.internal.ui.JSDTElementsFilter"
+          description="%jsdtElementFilter_desc"
+          id="tern.eclipse.ide.jsdt.ui.JSDTElementFilter"
+          name="%jsdtElementFilter"
+          visibleInUI="true">
+      </commonFilter>
+    </extension>
+    <extension
+           point="org.eclipse.core.runtime.adapters">
+        <factory
+              adaptableType="org.eclipse.wst.jsdt.core.IJavaScriptUnit"
+              class="tern.eclipse.ide.jsdt.internal.ui.JsdtUiToTernUiAdapter">
+           <adapter
+                 type="tern.eclipse.ide.core.resources.TernDocumentFile">
+           </adapter>
+        </factory>
+     </extension>
 	 
+	<extension
+         point="org.eclipse.ui.navigator.viewer">
+      <viewerContentBinding
+            viewerId="org.eclipse.wst.jsdt.ui.outline">
+         <includes>
+            <contentExtension
+                  pattern="tern.eclipse.ide.ui.navigatorContent"/>
+            <contentExtension
+                  pattern="tern.eclipse.ide.jsdt.ui.linkHelper"/>
+            <contentExtension
+                  pattern="tern.eclipse.ide.jsdt.ui.JSDTElementFilter"/>
+         </includes>
+      </viewerContentBinding>
+   </extension>
 </plugin>        

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/src/tern/eclipse/ide/jsdt/internal/ui/JSDTElementsFilter.java
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/src/tern/eclipse/ide/jsdt/internal/ui/JSDTElementsFilter.java
@@ -1,0 +1,53 @@
+package tern.eclipse.ide.jsdt.internal.ui;
+
+import java.util.ArrayList;
+
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.wst.jsdt.core.IJavaScriptElement;
+
+import tern.server.protocol.outline.JSNode;
+
+public class JSDTElementsFilter extends ViewerFilter {
+
+	public JSDTElementsFilter() {
+		// TODO Auto-generated constructor stub
+	}
+
+	@Override
+	public Object[] filter(Viewer viewer, Object parent, Object[] elements) {
+		int size = elements.length;
+		ArrayList<Object> out = new ArrayList<Object>(size);
+		for (int i = 0; i < size; ++i) {
+			if (elements[i] instanceof JSNode) {
+				out.add(elements[i]);
+			} else if (elements[i] instanceof IJavaScriptElement) {
+				if (!containsTernNode(elements, (IJavaScriptElement)elements[i])) {
+					out.add(elements[i]);
+				}
+			}
+		}
+		return out.toArray();
+	}
+
+
+	private boolean containsTernNode(Object[] elements, IJavaScriptElement jsdtElement) {
+		for (Object element : elements) {
+			if (element instanceof JSNode) {
+				JSNode node = (JSNode) element;
+				// could also use location in file node.getStart() 
+				if (node.getName() != null && node.getName().equalsIgnoreCase(jsdtElement.getElementName())) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean select(Viewer viewer, Object parentElement, Object element) {
+		// method should never be called as we directly override "filter"
+		return false;
+	}
+
+}

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/src/tern/eclipse/ide/jsdt/internal/ui/JSDTTernLinkHelper.java
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/src/tern/eclipse/ide/jsdt/internal/ui/JSDTTernLinkHelper.java
@@ -1,0 +1,49 @@
+package tern.eclipse.ide.jsdt.internal.ui;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.ide.ResourceUtil;
+import org.eclipse.ui.navigator.ILinkHelper;
+import org.eclipse.wst.jsdt.core.IJavaScriptElement;
+import org.eclipse.wst.jsdt.core.JavaScriptCore;
+import org.eclipse.wst.jsdt.internal.ui.javaeditor.EditorUtility;
+import org.eclipse.wst.jsdt.ui.JavaScriptUI;
+
+import tern.eclipse.ide.ui.utils.EditorUtils;
+import tern.server.protocol.outline.JSNode;
+
+public class JSDTTernLinkHelper implements ILinkHelper {
+
+	public void activateEditor(IWorkbenchPage page, IStructuredSelection selection) {
+		if (!selection.isEmpty()) {
+			if (selection.getFirstElement() instanceof JSNode) {
+				JSNode node = (JSNode) selection.getFirstElement();
+				IFile file = null; //ternFile.getFile();
+				Long start = node.getStart();
+				Long end = node.getEnd();
+				EditorUtils.openInEditor(
+						file,
+						start != null ? start.intValue() : -1,
+						start != null && end != null ? end.intValue()
+								- start.intValue() : -1, true);
+
+			}
+		}
+	}
+
+	public IStructuredSelection findSelection(IEditorInput input) {
+		IJavaScriptElement element= JavaScriptUI.getEditorInputJavaElement(input);
+		if (element == null) {
+			IFile file = ResourceUtil.getFile(input);
+			if (file != null) {
+				element= JavaScriptCore.create(file);
+			}
+		}
+		return (element != null) ? new StructuredSelection(element) : StructuredSelection.EMPTY;
+	}
+
+}

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/src/tern/eclipse/ide/jsdt/internal/ui/JsdtUiToTernUiAdapter.java
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/src/tern/eclipse/ide/jsdt/internal/ui/JsdtUiToTernUiAdapter.java
@@ -1,0 +1,44 @@
+package tern.eclipse.ide.jsdt.internal.ui;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IAdapterFactory;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.wst.jsdt.core.IJavaScriptUnit;
+
+import tern.TernResourcesManager;
+import tern.eclipse.ide.core.TernCorePlugin;
+import tern.eclipse.ide.core.resources.TernDocumentFile;
+import tern.eclipse.ide.ui.utils.EditorUtils;
+
+public class JsdtUiToTernUiAdapter implements IAdapterFactory {
+
+	@Override
+	public Object getAdapter(Object adaptableObject, Class/*<T>*/ adapterType) {
+	//public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
+		if (TernDocumentFile.class.equals(adapterType)) {
+			IFile file = null;
+			if (adaptableObject instanceof IFile) {
+				file = (IFile)adaptableObject;
+			} else if (adaptableObject instanceof IJavaScriptUnit) {
+				file = (IFile) ((IJavaScriptUnit)adaptableObject).getResource();
+			}
+			if (file != null && TernResourcesManager.isJSFile(file)) {
+				IProject project = file.getProject();
+				if (TernCorePlugin.hasTernNature(project)) {
+					IDocument document = EditorUtils.getDocument(file);
+					if (document != null) {
+						return /*(T)*/ new TernDocumentFile(file, document);
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?>[] getAdapterList() {
+		return new Class<?>[] { TernDocumentFile.class };
+	}
+
+}

--- a/eclipse/tern.eclipse.ide.ui/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.ui/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench.texteditor,
  tern.eclipse,
  org.eclipse.core.expressions,
- org.eclipse.ui.views
+ org.eclipse.ui.views,
+ org.eclipse.ui.navigator
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tern.eclipse.ide.ui.TernUIPlugin
 Export-Package: tern.eclipse.ide.ui,

--- a/eclipse/tern.eclipse.ide.ui/plugin.properties
+++ b/eclipse/tern.eclipse.ide.ui/plugin.properties
@@ -31,3 +31,4 @@ TernValidationPropertyPage.name=Validation
 
 # Extension points
 ternModuleDescriptors.name=Tern module descriptors
+testNavigatorContent_name=JavaScript content (with Tern)

--- a/eclipse/tern.eclipse.ide.ui/plugin.xml
+++ b/eclipse/tern.eclipse.ide.ui/plugin.xml
@@ -256,50 +256,36 @@
             class="tern.eclipse.ide.internal.ui.views.TernOutlineView"
             id="tern.eclipse.ide.ui.views.TernOutlineView">
       </view>
+      <view
+            category="org.eclipse.wst.jsdt.ui.java"
+            class="tern.eclipse.ide.internal.ui.views.TernOutlineView2"
+            icon="$nl$/icons/full/eview16/tern-outline.png"
+            id="tern.eclipse.ide.ui.views.TernOutlineView2"
+            name="tern.eclipse.ide.ui.views.TernOutlineView2">
+      </view>
   </extension>
-   
-  <!--        
-  <extension
-			point="org.eclipse.ui.navigator.navigatorContent">
-		<navigatorContent
-				activeByDefault="true"
-				contentProvider="tern.eclipse.ide.internal.ui.views.TernOutlineContentProvider"
-				id="tern.eclipse.ide.internal.views.TernOutlineContent"
-				labelProvider="tern.eclipse.ide.internal.ui.views.TernOutlineLabelProvider"
-				name="%commonNavigatorContentName"
-				priority="low">
-			<triggerPoints>
-			     <or>
-					<and>
-                 		<instanceof	value="org.eclipse.core.resources.IResource" />						
-					</and>
-				</or>
-			</triggerPoints>
-			<possibleChildren>
-				<or>
-					<and>
-                 		<instanceof	value="org.eclipse.core.resources.IResource" />
-					</and>
-				</or>
-			</possibleChildren> 
-		</navigatorContent>
+   <extension
+         point="org.eclipse.ui.navigator.navigatorContent">
+      <navigatorContent
+            contentProvider="tern.eclipse.ide.internal.ui.views.TernOutlineContentProvider"
+            icon="icons/full/obj16/logo.png"
+            id="tern.eclipse.ide.ui.navigatorContent"
+            labelProvider="tern.eclipse.ide.internal.ui.views.TernOutlineLabelProvider"
+            name="%testNavigatorContent_name">
+         <triggerPoints>
+         </triggerPoints>
+      </navigatorContent>
    </extension>
-              
-  <extension
-      point="org.eclipse.ui.navigator.viewer">
-    <viewer
-         viewerId="tern.eclipse.ide.ui.views.TernOutlineView">
-    </viewer>
-    <viewerContentBinding
-         viewerId="tern.eclipse.ide.ui.views.TernOutlineView">
-      <includes>
-         <contentExtension
-               isRoot="false"
-               pattern="tern.eclipse.ide.internal.views.TernOutlineContent">
-         </contentExtension>
-      </includes>
-    </viewerContentBinding>
-  </extension>
-  --> 
+   <extension
+         point="org.eclipse.ui.navigator.viewer">
+      <viewerContentBinding
+            viewerId="tern.eclipse.ide.ui.outline">
+         <includes>
+            <contentExtension
+                  pattern="tern.eclipse.ide.ui.navigatorContent">
+            </contentExtension>
+         </includes>
+      </viewerContentBinding>
+   </extension>
               	       	 
 </plugin>        

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.java
@@ -146,6 +146,7 @@ public final class TernUIMessages extends NLS {
 
 	// Refresh outline
 	public static String refreshOutline;
+	public static String TernOutline_computing;
 
 	private TernUIMessages() {
 	}

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.properties
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/TernUIMessages.properties
@@ -124,3 +124,4 @@ TerminateTernServerAction_tooltip=Stop tern server
 
 # Outline
 refreshOutline=Refresh tern outline
+TernOutline_computing=Parsing with Tern...

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/views/TernOutlineContentProvider.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/views/TernOutlineContentProvider.java
@@ -10,37 +10,92 @@
  */
 package tern.eclipse.ide.internal.ui.views;
 
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.text.DocumentEvent;
-import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
 
+import tern.eclipse.ide.core.IIDETernProject;
+import tern.eclipse.ide.core.TernCorePlugin;
+import tern.eclipse.ide.core.resources.TernDocumentFile;
+import tern.eclipse.ide.internal.ui.TernUIMessages;
+import tern.server.TernPlugin;
 import tern.server.protocol.outline.JSNode;
+import tern.server.protocol.outline.TernOutlineQuery;
 
 public class TernOutlineContentProvider implements ITreeContentProvider, IDocumentListener {
 
+	public static final Object COMPUTING_NODE = new Object();
 	private static final Object[] EMPTY_ARRAY = new Object[0];
+	private static final int UPDATE_DELAY = 500;
+	
+	private Viewer viewer;
+	private TernDocumentFile document;
+	private Job refreshJob;
+	private boolean parsed = false;
+	private TernOutline outline = null;
+	
+	public TernOutlineContentProvider() {
+		this.refreshJob = new Job(TernUIMessages.refreshOutline) {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				parsed = false;
+				if (document == null) {
+					return Status.OK_STATUS;
+				}
+				try {
+					IIDETernProject ternProject = TernCorePlugin.getTernProject(document.getFile().getProject());
+					if (ternProject != null && ternProject.hasPlugin(TernPlugin.outline)) {
+						// Call tern-outline
+						TernOutlineQuery query = new TernOutlineQuery(document.getFileName());
+						outline = new TernOutline(document);
+						ternProject.request(query, document, outline);
+						parsed = true;
+						// Refresh UI Tree
+						Display.getDefault().syncExec(new Runnable() {
 
-	private final TernContentOutlinePage outlinePage;
-
-	public TernOutlineContentProvider(TernContentOutlinePage outlinePage) {
-		this.outlinePage = outlinePage;
+							@Override
+							public void run() {
+								Control refreshControl = viewer.getControl();
+								if ((refreshControl != null) && !refreshControl.isDisposed()) {
+									viewer.refresh();
+									//viewer.expandAll();
+								}
+							}
+						});
+					}
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		refreshJob.setSystem(true);
+		refreshJob.setPriority(Job.SHORT);
 	}
+	
 
 	@Override
 	public Object[] getElements(Object element) {
-		if (element instanceof TernOutline) {
-			return ((TernOutline) element).getRoot().getChildren().toArray();
-		} else if (element instanceof JSNode) {
-			return ((JSNode) element).getChildren().toArray();
+		if (!parsed) {
+			return new Object[] { COMPUTING_NODE };
 		}
-		return EMPTY_ARRAY;
+		return outline.getRoot().getChildren().toArray();
 	}
 
 	@Override
 	public Object[] getChildren(Object element) {
-		return getElements(element);
+		if (element instanceof JSNode) {
+			return ((JSNode) element).getChildren().toArray();
+		}
+		return EMPTY_ARRAY;
 	}
 
 	@Override
@@ -61,29 +116,37 @@ public class TernOutlineContentProvider implements ITreeContentProvider, IDocume
 
 	@Override
 	public void dispose() {
-
+		this.refreshJob.cancel();
+		this.document.getDocument().removeDocumentListener(this);
 	}
 
 	@Override
 	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-		if ((oldInput != null) && (oldInput instanceof TernOutline)) {
-			IDocument document = ((TernOutline) oldInput).getTernFile().getDocument();
-			document.removeDocumentListener(this);
+		this.viewer = viewer;
+		if (this.document != null) {
+			document.getDocument().removeDocumentListener(this);
 		}
-		if ((newInput != null) && (newInput instanceof TernOutline)) {
-			IDocument document = ((TernOutline) newInput).getTernFile().getDocument();
-			document.addDocumentListener(this);
+		if (newInput instanceof TernDocumentFile) {
+			this.document = (TernDocumentFile) newInput;
+		} else if (newInput instanceof IAdaptable) {
+			this.document = (TernDocumentFile) ((IAdaptable)newInput).getAdapter(TernDocumentFile.class);
 		}
+		if (this.document != null) {
+			document.getDocument().addDocumentListener(this);
+		}
+		this.refreshJob.schedule();
 	}
-
+	
 	@Override
 	public void documentChanged(DocumentEvent event) {
-		
+		if (this.refreshJob.getState() != Job.NONE) {
+			this.refreshJob.cancel();
+		}
+		this.refreshJob.schedule(UPDATE_DELAY);
 	}
-
+	
 	@Override
 	public void documentAboutToBeChanged(DocumentEvent event) {
-		outlinePage.refreshOutline();
 	}
-
+	
 }

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/views/TernOutlineLabelProvider.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/views/TernOutlineLabelProvider.java
@@ -15,6 +15,9 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.swt.graphics.Image;
 
+import tern.eclipse.ide.internal.ui.TernUIMessages;
+import tern.eclipse.ide.ui.ImageResource;
+import tern.eclipse.ide.ui.TernUIPlugin;
 import tern.eclipse.jface.images.TernImagesRegistry;
 import tern.server.protocol.outline.JSNode;
 import tern.utils.StringUtils;
@@ -23,6 +26,9 @@ public class TernOutlineLabelProvider extends LabelProvider implements IStyledLa
 
 	@Override
 	public String getText(Object element) {
+		if (element == TernOutlineContentProvider.COMPUTING_NODE) {
+			return TernUIMessages.TernOutline_computing;
+		}
 		if (element instanceof JSNode) {
 			return ((JSNode) element).getName();
 		}
@@ -31,6 +37,9 @@ public class TernOutlineLabelProvider extends LabelProvider implements IStyledLa
 
 	@Override
 	public Image getImage(Object element) {
+		if (element == TernOutlineContentProvider.COMPUTING_NODE) {
+			return ImageResource.getImage(ImageResource.IMG_LOGO);
+		}
 		if (element instanceof JSNode) {
 			JSNode jsNode = (JSNode) element;
 			String jsType = jsNode.getType();
@@ -46,6 +55,9 @@ public class TernOutlineLabelProvider extends LabelProvider implements IStyledLa
 
 	@Override
 	public StyledString getStyledText(Object element) {
+		if (element == TernOutlineContentProvider.COMPUTING_NODE) {
+			return new StyledString(TernUIMessages.TernOutline_computing);
+		}
 		if (element instanceof JSNode) {
 			JSNode node = ((JSNode) element);
 			StyledString buff = new StyledString(StringUtils.isEmpty(node.getName()) ? "" : node.getName());
@@ -56,6 +68,6 @@ public class TernOutlineLabelProvider extends LabelProvider implements IStyledLa
 			}
 			return buff;
 		}
-		return null;
+		return new StyledString(getText(element));
 	}
 }


### PR DESCRIPTION
This will allow easier integration with Project Explorer and JSDT outline.

What's done:
* Register TernOutlineContentProvider as a common provider
* Loose coupling between TernOutlineProvider and TernOutlinePage
* Turn the Tern Outline into a common navigator and define necessary extensions to consume the right provider
* Contribute to JSDT Outlne via CNF (to see Tern contributing to JSDT outline, one needs to use the JSDT patches attached to https://bugs.eclipse.org/bugs/show_bug.cgi?id=479132 )
* Contribute some adapters to easily map Tern model to JSDT model (only very few elements so far)

This is a patch for issue #337