### PR TITLE
Initializing module options map in advance to avoid loosing reference.

### DIFF
--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernNatureAdaptersManager.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernNatureAdaptersManager.java
@@ -243,7 +243,7 @@ public class TernNatureAdaptersManager implements IRegistryChangeListener {
 		}
 
 		List<ITernModule> contributedModules = new ArrayList<ITernModule>();
-		Map<ITernModule, JsonObject> moduleOptions = null;
+		Map<ITernModule, JsonObject> moduleOptions = new HashMap<ITernModule, JsonObject>();
 
 		// add default module from preferences
 		ITernModule moduleFromPreferences = null;
@@ -290,7 +290,7 @@ public class TernNatureAdaptersManager implements IRegistryChangeListener {
 		// loop for collected sorted modules
 		JsonObject options = null;
 		for (ITernModule module : contributedModules) {
-			options = moduleOptions != null ? moduleOptions.get(module) : null;
+			options = moduleOptions.get(module);
 			TernModuleHelper.update(module, options, ternProject);
 		}
 
@@ -306,9 +306,6 @@ public class TernNatureAdaptersManager implements IRegistryChangeListener {
 			if (!contributedModules.contains(module)) {
 				contributedModules.add(module);
 				if (defaultModule.getOptions() != null) {
-					if (moduleOptions == null) {
-						moduleOptions = new HashMap<ITernModule, JsonObject>();
-					}
 					moduleOptions.put(module, defaultModule.getOptions());
 				}
 			}


### PR DESCRIPTION
When configuring the default static modules in extension point "tern.eclipse.ide.core.ternNatureAdapters", an "options" object is allowed as an attribute of <module> tag. However, this attribute is ignored even it is properly set:

	<extension point="tern.eclipse.ide.core.ternNatureAdapters">
    	<ternAdaptToNature
        	id="mynature"
        	<defaultModules>
	            <module name="jshint" withDependencies="true" options="{&quot;config&quot; : {&quot;esnext&quot; : true}}"/>
    	    </defaultModules>
    	</ternAdaptToNature>
	</extension>
