### PR TITLE
Make tern query API more flexible and consice.

### DIFF
--- a/core/tern.core/src/tern/ITernProject.java
+++ b/core/tern.core/src/tern/ITernProject.java
@@ -26,20 +26,10 @@ import tern.scriptpath.ITernScriptPath;
 import tern.server.ITernDef;
 import tern.server.ITernPlugin;
 import tern.server.ITernServer;
+import tern.server.protocol.ITernResultsCollector;
 import tern.server.protocol.TernQuery;
-import tern.server.protocol.completions.ITernCompletionCollector;
-import tern.server.protocol.definition.ITernDefinitionCollector;
-import tern.server.protocol.guesstypes.ITernGuessTypesCollector;
-import tern.server.protocol.guesstypes.TernGuessTypesQuery;
-import tern.server.protocol.highlight.ITernHighlightCollector;
-import tern.server.protocol.highlight.TernHighlightQuery;
 import tern.server.protocol.lint.ITernLintCollector;
-import tern.server.protocol.outline.ITernOutlineCollector;
-import tern.server.protocol.outline.TernOutlineQuery;
 import tern.server.protocol.push.IMessageHandler;
-import tern.server.protocol.refs.ITernRefCollector;
-import tern.server.protocol.refs.TernRefsQuery;
-import tern.server.protocol.type.ITernTypeCollector;
 
 /**
  * Tern project API.
@@ -75,7 +65,8 @@ public interface ITernProject extends ITernAdaptable {
 	/**
 	 * Set ECMAScript version
 	 * 
-	 * @param ecmaVersion the ECMAScript version 
+	 * @param ecmaVersion
+	 *            the ECMAScript version
 	 */
 	void setEcmaVersion(EcmaVersion ecmaVersion);
 
@@ -85,7 +76,7 @@ public interface ITernProject extends ITernAdaptable {
 	 * @return ECMAScript version.
 	 */
 	EcmaVersion getEcmaVersion();
-	
+
 	// --------------------- JSON Type Definitions
 
 	/**
@@ -258,30 +249,12 @@ public interface ITernProject extends ITernAdaptable {
 	 */
 	Object getAdapter(@SuppressWarnings("rawtypes") Class adapterClass);
 
-	// ---------- Completion
+	// ---------- Generic query API
 	void request(TernQuery query, ITernFile file,
-			ITernCompletionCollector collector) throws IOException,
-			TernException;
+			ITernResultsCollector collector) throws IOException, TernException;
 
 	void request(TernQuery query, JsonArray names, ITernScriptPath scriptPath,
-			Node domNode, ITernFile file, ITernCompletionCollector collector)
-			throws IOException, TernException;
-
-	// ---------- Definition
-	void request(TernQuery query, ITernFile file,
-			ITernDefinitionCollector collector) throws IOException,
-			TernException;
-
-	void request(TernQuery query, JsonArray names, ITernScriptPath scriptPath,
-			Node domNode, ITernFile file, ITernDefinitionCollector collector)
-			throws IOException, TernException;
-
-	// ---------- Type
-	void request(TernQuery query, ITernFile file, ITernTypeCollector collector)
-			throws IOException, TernException;
-
-	void request(TernQuery query, JsonArray names, ITernScriptPath scriptPath,
-			Node domNode, ITernFile file, ITernTypeCollector collector)
+			Node domNode, ITernFile file, ITernResultsCollector collector)
 			throws IOException, TernException;
 
 	// ---------- Lint
@@ -291,26 +264,6 @@ public interface ITernProject extends ITernAdaptable {
 	void request(TernQuery query, ITernLintCollector collector)
 			throws IOException, TernException;
 
-	// ---------- Guess types
-
-	void request(TernGuessTypesQuery query, ITernFile file,
-			ITernGuessTypesCollector collector) throws IOException,
-			TernException;
-
-	// ---------- Outline
-
-	void request(TernOutlineQuery query, ITernFile file,
-			ITernOutlineCollector collector) throws IOException,
-			TernException;
-
-	// ---------- Highlight
-	
-	void request(TernHighlightQuery query, ITernHighlightCollector collector) throws IOException, TernException;
-	
-	// ---------- Refs
-	
-	void request(TernRefsQuery query, ITernFile file, ITernRefCollector collector) throws IOException, TernException;
-	
 	/**
 	 * Returns the tern repository used by the tern project.
 	 * 

--- a/core/tern.core/src/tern/resources/TernProject.java
+++ b/core/tern.core/src/tern/resources/TernProject.java
@@ -47,24 +47,13 @@ import tern.scriptpath.impl.dom.DOMElementsScriptPath;
 import tern.server.ITernDef;
 import tern.server.ITernPlugin;
 import tern.server.ITernServer;
-import tern.server.ITernServerListener;
 import tern.server.TernDef;
+import tern.server.protocol.ITernResultsCollector;
 import tern.server.protocol.JsonHelper;
 import tern.server.protocol.TernDoc;
 import tern.server.protocol.TernQuery;
-import tern.server.protocol.completions.ITernCompletionCollector;
-import tern.server.protocol.definition.ITernDefinitionCollector;
-import tern.server.protocol.guesstypes.ITernGuessTypesCollector;
-import tern.server.protocol.guesstypes.TernGuessTypesQuery;
-import tern.server.protocol.highlight.ITernHighlightCollector;
-import tern.server.protocol.highlight.TernHighlightQuery;
 import tern.server.protocol.lint.ITernLintCollector;
-import tern.server.protocol.outline.ITernOutlineCollector;
-import tern.server.protocol.outline.TernOutlineQuery;
 import tern.server.protocol.push.IMessageHandler;
-import tern.server.protocol.refs.ITernRefCollector;
-import tern.server.protocol.refs.TernRefsQuery;
-import tern.server.protocol.type.ITernTypeCollector;
 import tern.utils.IOUtils;
 
 /**
@@ -599,44 +588,14 @@ public class TernProject extends JsonObject implements ITernProject {
 	}
 
 	@Override
-	public void request(TernQuery query, ITernFile file, ITernCompletionCollector collector)
+	public void request(TernQuery query, ITernFile file, ITernResultsCollector collector)
 			throws IOException, TernException {
 		request(query, null, null, null, file, collector);
 	}
 
 	@Override
 	public void request(TernQuery query, JsonArray names, ITernScriptPath scriptPath, Node domNode, ITernFile file,
-			ITernCompletionCollector collector) throws IOException, TernException {
-		TernDoc doc = new TernDoc(query);
-		synchronize(doc, names, scriptPath, domNode, file);
-		ITernServer server = getTernServer();
-		server.request(doc, collector);
-	}
-
-	@Override
-	public void request(TernQuery query, ITernFile file, ITernDefinitionCollector collector)
-			throws IOException, TernException {
-		request(query, null, null, null, file, collector);
-	}
-
-	@Override
-	public void request(TernQuery query, JsonArray names, ITernScriptPath scriptPath, Node domNode, ITernFile file,
-			ITernDefinitionCollector collector) throws IOException, TernException {
-		TernDoc doc = new TernDoc(query);
-		synchronize(doc, names, scriptPath, domNode, file);
-		ITernServer server = getTernServer();
-		server.request(doc, collector);
-	}
-
-	@Override
-	public void request(TernQuery query, ITernFile file, ITernTypeCollector collector)
-			throws IOException, TernException {
-		request(query, null, null, null, file, collector);
-	}
-
-	@Override
-	public void request(TernQuery query, JsonArray names, ITernScriptPath scriptPath, Node domNode, ITernFile file,
-			ITernTypeCollector collector) throws IOException, TernException {
+			ITernResultsCollector collector) throws IOException, TernException {
 		TernDoc doc = new TernDoc(query);
 		synchronize(doc, names, scriptPath, domNode, file);
 		ITernServer server = getTernServer();
@@ -661,42 +620,6 @@ public class TernProject extends JsonObject implements ITernProject {
 	@Override
 	public void request(TernQuery query, ITernLintCollector collector) throws IOException, TernException {
 		request(query, null, true, collector);
-	}
-
-	@Override
-	public void request(TernGuessTypesQuery query, ITernFile file, ITernGuessTypesCollector collector)
-			throws IOException, TernException {
-		TernDoc doc = new TernDoc(query);
-		synchronize(doc, null, null, null, file);
-		ITernServer server = getTernServer();
-		server.request(doc, collector);
-	}
-
-	@Override
-	public void request(TernOutlineQuery query, ITernFile file, ITernOutlineCollector collector)
-			throws IOException, TernException {
-		TernDoc doc = new TernDoc(query);
-		synchronize(doc, null, null, null, file);
-		ITernServer server = getTernServer();
-		server.request(doc, collector);
-	}
-
-	@Override
-	public void request(TernHighlightQuery query, ITernHighlightCollector collector) throws IOException, TernException {
-		TernDoc doc = new TernDoc(query);
-		ITernServer server = getTernServer();
-		server.request(doc, collector);
-	}
-
-	@Override
-	public void request(TernRefsQuery query, ITernFile file, ITernRefCollector collector)
-			throws IOException, TernException {
-		TernDoc doc = new TernDoc(query);
-		if (file != null) {
-			synchronize(doc, null, null, null, file);
-		}
-		ITernServer server = getTernServer();
-		server.request(doc, collector);
 	}
 
 	@Override

--- a/core/tern.core/src/tern/server/protocol/ITernCustomResultsCollector.java
+++ b/core/tern.core/src/tern/server/protocol/ITernCustomResultsCollector.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2015, Genuitec, LLC
+ * All Rights Reserved.
+ */
+package tern.server.protocol;
+
+public interface ITernCustomResultsCollector extends ITernResultsCollector {
+
+	ITernResultProcessor<?> getResultsProcessor();
+	
+}

--- a/core/tern.core/src/tern/server/protocol/TernResultsProcessorsFactory.java
+++ b/core/tern.core/src/tern/server/protocol/TernResultsProcessorsFactory.java
@@ -50,7 +50,9 @@ public class TernResultsProcessorsFactory {
 	@SuppressWarnings("unchecked")
 	private static <T extends ITernResultsCollector> ITernResultProcessor<T> getProcessor(
 			T collector) throws TernException {
-		if (collector instanceof ITernCompletionCollector) {
+		if (collector instanceof ITernCustomResultsCollector) {
+			return (ITernResultProcessor<T>) ((ITernCustomResultsCollector)collector).getResultsProcessor();
+		} else if (collector instanceof ITernCompletionCollector) {
 			return (ITernResultProcessor<T>) TernCompletionsResultProcessor.INSTANCE;
 		} else if (collector instanceof ITernRefCollector) {
 			return (ITernResultProcessor<T>) TernRefsResultProcessor.INSTANCE;						
@@ -69,7 +71,7 @@ public class TernResultsProcessorsFactory {
 		} else {
 			throw new TernException(
 					MessageFormat
-							.format("Tern results collector {0} does not implement any of the supported interfaces", //$NON-NLS-1$
+							.format("Tern results collector {0} does not implement any of the supported interfaces nor does it provide the processor through ITernCustomResultsCollector interface.", //$NON-NLS-1$
 									collector.getClass().getName()));
 		}
 	}

--- a/eclipse/tern.eclipse/src/tern/eclipse/jface/text/TernTokenScanner.java
+++ b/eclipse/tern.eclipse/src/tern/eclipse/jface/text/TernTokenScanner.java
@@ -88,7 +88,7 @@ public abstract class TernTokenScanner implements ITokenScanner {
 		if (ternProject != null) {
 			String text = document.get(collector.getOffset(), collector.getLength());
 			TernHighlightQuery query = new TernHighlightQuery(text);
-			ternProject.request(query, collector);
+			ternProject.request(query, null, collector);
 		}
 	}
 


### PR DESCRIPTION
I am working on some custom queries and it is a real PIA to add a support for a new query ;) Thus, I have cleared up the query API on ITernProject by providing a generic methods and only left Lint queries untouched as their code was different. As you can see, there are no code changes required in the query calls, as everything followed the same pattern, which was now generalized. It is also possible to define a new/custom query support without touching tern.core through ITernCustomResultsCollector - I guess that would be good for some proof of concept stuff like that highlighting thing you did, or for support for custom tern plugins. Please have a look at this ASAP (need this for my current task) and let me know if you have any questions!