### PR TITLE
Issue #6: Support partial file upload.

### DIFF
--- a/core/tern.core/src/tern/resources/TernFileSynchronizer.java
+++ b/core/tern.core/src/tern/resources/TernFileSynchronizer.java
@@ -208,7 +208,7 @@ public class TernFileSynchronizer implements ITernFileSynchronizer {
 
 			toRefreshLocal.removeAll(synced);
 			for (String toRemove : toRefreshLocal) {
-				doc.delFile(toRemove); //$NON-NLS-1$
+				doc.delFile(toRemove);
 			}
 
 			// perform actual synchronization with the server
@@ -360,6 +360,15 @@ public class TernFileSynchronizer implements ITernFileSynchronizer {
 			updateSentFiles(doc);
 			// sync is performed asynchronously
 			uploader.request(doc);
+		}
+	}
+	
+	protected String getSentFileContent(String file) {
+		readLock.lock();
+		try {
+			return sentFiles.get(file);
+		} finally {
+			readLock.unlock();
 		}
 	}
 

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/resources/IDETernFileSynchronizer.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/resources/IDETernFileSynchronizer.java
@@ -9,14 +9,24 @@
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
  *  Piotr Tomiak <piotr@genuitec.com> - refactoring of file management API
  *  								  - asynchronous file upload
+ *                                    - partial file upload
  */
 package tern.eclipse.ide.internal.core.resources;
 
-import org.eclipse.core.resources.IFile;
+import java.io.IOException;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.text.IDocument;
+
+import com.eclipsesource.json.JsonValue;
+
+import tern.ITernFile;
 import tern.ITernProject;
 import tern.resources.ITernFileUploader;
 import tern.resources.TernFileSynchronizer;
+import tern.server.protocol.TernDoc;
+import tern.server.protocol.TernFile;
+import tern.server.protocol.TernQuery;
 
 /**
  * Extension of {@link TernFileManager} to works with Eclipse {@link IFile}
@@ -24,6 +34,8 @@ import tern.resources.TernFileSynchronizer;
  */
 public class IDETernFileSynchronizer extends TernFileSynchronizer {
 
+	protected static final int BIG_FILE = 500;
+	
 	/**
 	 * Constructor of file manager with the owner Eclipse project.
 	 */
@@ -34,6 +46,95 @@ public class IDETernFileSynchronizer extends TernFileSynchronizer {
 	@Override
 	protected ITernFileUploader createTernFileUploader() {
 		return new IDETernFileUploader(getProject());
+	}
+
+	@Override
+	protected void addJSFile(TernDoc doc, ITernFile file) throws IOException {
+		TernQuery query = doc.getQuery();
+		String fileName = file.getFullName(getProject());
+		query.setFile(fileName);
+		IDocument document = (IDocument) file.getAdapter(IDocument.class);
+		//include file as a part of the tern doc
+		if (document != null) {
+			String text = document.get();
+			String oldText = getSentFileContent(fileName);
+			if (text.equals(oldText)) {
+				if (!getTernFileUploader().cancel(fileName)) {
+					//no need to synchronize as file has already been sent to the server
+					return;
+				}
+				//continue to include a whole file in the request
+			} else if (oldText != null &&
+					//do partial content assist only in big files
+					document.getNumberOfLines() > BIG_FILE) {
+				try {
+					int start;
+					for (start = 0; 
+							start < text.length() && start < oldText.length() &&
+							text.charAt(start) == oldText.charAt(start); 
+							start++);
+					int end;
+					int offset = oldText.length() - text.length();
+					for (end = text.length() - 1; 
+							end > 0 && end + offset > 0 &&
+							text.charAt(end) == oldText.charAt(end + offset);
+							end--);
+					int startLine = document.getLineOfOffset(start);
+					int endLine = document.getLineOfOffset(end);
+
+					int selEndLine;
+					if (query.get("end") != null) { //$NON-NLS-1$
+						selEndLine = document.getLineOfOffset(query.get("end").asInt()); //$NON-NLS-1$
+					} else {
+						selEndLine = -1;
+					}
+					int selStartLine;
+					if (query.get("start") != null) { //$NON-NLS-1$
+						selStartLine = document.getLineOfOffset(query.get("start").asInt()); //$NON-NLS-1$
+					} else {
+						selStartLine = selEndLine;
+					}
+					
+					if (startLine <= endLine && 
+							endLine - startLine < 100 &&
+							//Selection should be part of modified lines. 
+							//Tolerate 2 lines before and 2 lines after.
+							!(selStartLine-2 > endLine || selEndLine+2 < startLine)) {
+						startLine -= 50;
+						if (startLine < 0) {
+							startLine = 0;
+						}
+						endLine += 20;
+						if (endLine >= document.getNumberOfLines()) {
+							endLine = document.getNumberOfLines() - 1;
+						}
+						
+						start = document.getLineOffset(startLine);
+						end = document.getLineOffset(endLine);
+						
+						String textPart = document.get(start, end-start);
+						
+						doc.addFile(new TernFile(fileName, textPart, null, start));
+						query.setFile("#" + (doc.getFiles().size() - 1)); //$NON-NLS-1$
+						JsonValue val = query.get("end"); //$NON-NLS-1$
+						if (val != null) {
+							query.setEnd(val.asInt() - start);
+						}
+						val = query.get("start"); //$NON-NLS-1$
+						if (val != null) {
+							query.add("start", val.asInt() - start); //$NON-NLS-1$
+						}
+						//all's fine - return
+						return;
+					}
+				} catch (Exception e) {
+					getProject().handleException(e);
+				}
+			}
+		}
+		//fallback - include whole file in the request
+		TernFile tf = file.toTernServerFile(getProject());
+		doc.addFile(tf);
 	}
 	
 }


### PR DESCRIPTION
Tern has very limited support for partial file upload, therefore the file part has to be carefully prepared. There is not much intelligence done and the fragment is parsed and inferred as it is provided, it is not magically subsituted, therefore there is context needed for better inferring and some restrictions. It is also not viable to do partial upload for smaller files, therefore a limit of 500 lines is set.

It goes as follows: first we detect how the file has changed since it was last sent to the server. Next, we ensure that query (e.g. completion) is requested in the modified region or close to it, otherwise provided results might be inaccurate - Tern only analyses the sent fragment. So the supported case is content assist or query close to the modified region. We also ensure that number of modified lines is no higher than 100, doing changes in multiple parts of document require full rescan. After that we resize the selection to include 50 lines before and 20 lines after for a better context. Next the query is updated to include the part file and offsets are adjusted. The rest of the stuff goes as before.