### PR TITLE
Issue #394: Always use document contents for IFile.

### DIFF
--- a/eclipse/tern.eclipse.ide.core/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.core/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse,
  org.eclipse.jface.text,
  org.eclipse.core.commands,
- tern.websocket.provider
+ tern.websocket.provider,
+ org.eclipse.core.filebuffers
 Export-Package: tern.eclipse.ide.core,
  tern.eclipse.ide.core.preferences,
  tern.eclipse.ide.core.resources,


### PR DESCRIPTION
An alternative solution, by which uploaded contents of files will be equal to contents of opened editors always.