### PR TITLE
Adding private constructor to util classes (containing  static methods only)

### DIFF
--- a/core/tern.core.tests/src/tern/server/nodejs/NodejsTernServerFactory.java
+++ b/core/tern.core.tests/src/tern/server/nodejs/NodejsTernServerFactory.java
@@ -22,6 +22,9 @@ import tern.server.nodejs.process.PrintNodejsProcessListener;
 
 public class NodejsTernServerFactory {
 
+	private NodejsTernServerFactory() {
+	}
+
 	public static ITernServer createServer(ITernProject project)
 			throws TernException {
 		NodejsProcessManager.getInstance().init(

--- a/core/tern.core.tests/src/tern/server/nodejs/process/PathHelper.java
+++ b/core/tern.core.tests/src/tern/server/nodejs/process/PathHelper.java
@@ -18,7 +18,10 @@ import tern.utils.ZipUtils;
 public class PathHelper {
 
 	private static final String NODE_VERSION = "4.2.4";
-	
+
+	private PathHelper() {
+	}
+
 	/**
 	 * Returns nodejs base dir switch OS.
 	 *

--- a/core/tern.core.tests/src/tern/server/rhino/RhinoTernServerFactory.java
+++ b/core/tern.core.tests/src/tern/server/rhino/RhinoTernServerFactory.java
@@ -18,6 +18,9 @@ import tern.server.nodejs.process.PathHelper;
 
 public class RhinoTernServerFactory {
 
+	private RhinoTernServerFactory() {
+	}
+
 	public static ITernServer createServer(ITernProject project) throws TernException {
 		project.setRepository(new TernRepository("ternjs", PathHelper.getTernRepositoryDir()));
 		RhinoTernServer server = new RhinoTernServer(project);		

--- a/core/tern.core/src/tern/TernResourcesManager.java
+++ b/core/tern.core/src/tern/TernResourcesManager.java
@@ -20,6 +20,9 @@ public class TernResourcesManager {
 	private static final InternalTernResourcesManager INSTANCE = InternalTernResourcesManager
 			.getInstance();
 
+	private TernResourcesManager() {
+	}
+
 	/**
 	 * Returns a tern project object associated with the specified resource. May
 	 * return null if resource doesn't point at a valid tern project.

--- a/core/tern.core/src/tern/angular/modules/DirectiveHelper.java
+++ b/core/tern.core/src/tern/angular/modules/DirectiveHelper.java
@@ -36,6 +36,9 @@ public class DirectiveHelper {
 		DELIMITERS.add('_'); // underscore delimiter
 	}
 
+	private DirectiveHelper() {
+	}
+
 	/**
 	 * 
 	 * Angular normalizes an element's tag and attribute name to determine which

--- a/core/tern.core/src/tern/angular/protocol/HTMLTernAngularHelper.java
+++ b/core/tern.core/src/tern/angular/protocol/HTMLTernAngularHelper.java
@@ -20,7 +20,10 @@ import tern.angular.modules.IDirectiveProvider;
 
 public class HTMLTernAngularHelper {
 
-	public static void populateScope(Node element, IDirectiveProvider provider,
+	private HTMLTernAngularHelper() {
+	}
+
+	public static void populateScope(Node element, IDirectiveProvider provider, 
 			Object project, TernAngularQuery query) {
 		TernAngularScope scope = query.getScope();
 		populateScope(element, scope, provider, project,

--- a/core/tern.core/src/tern/doc/JSDocumentHelper.java
+++ b/core/tern.core/src/tern/doc/JSDocumentHelper.java
@@ -16,6 +16,9 @@ import tern.server.protocol.completions.TernCompletionsQuery;
 
 public class JSDocumentHelper {
 
+	private JSDocumentHelper() {
+	}
+
 	public static TernDoc createDoc(IJSDocument doc) {
 
 		boolean changed = doc.isChanged();

--- a/core/tern.core/src/tern/repository/TernRepositoryHelper.java
+++ b/core/tern.core/src/tern/repository/TernRepositoryHelper.java
@@ -44,6 +44,9 @@ public class TernRepositoryHelper {
 	 */
 	public static final String DEFAULT_TERN_REPOSITORY_URL = "https://raw.githubusercontent.com/paulvi/tern-plugins/master/plugins.json";
 
+	private TernRepositoryHelper() {
+	}
+
 	/**
 	 * Load tern modules coming from the given repository.json URL.
 	 * 

--- a/core/tern.core/src/tern/server/TernExceptionFactory.java
+++ b/core/tern.core/src/tern/server/TernExceptionFactory.java
@@ -16,6 +16,9 @@ public class TernExceptionFactory {
 
 	private static final String NO_TYPE_FOUND_AT_THE_GIVEN_POSITION = "No type found at the given position.";
 
+	private TernExceptionFactory() {
+	}
+
 	public static TernException create(String message) {
 		if (message.indexOf(NO_TYPE_FOUND_AT_THE_GIVEN_POSITION) != - 1) {
 			return new TernNoTypeFoundAtPositionException(message);

--- a/core/tern.core/src/tern/server/protocol/JsonHelper.java
+++ b/core/tern.core/src/tern/server/protocol/JsonHelper.java
@@ -24,6 +24,9 @@ import com.eclipsesource.json.JsonValue;
  */
 public class JsonHelper {
 
+	private JsonHelper() {
+	}
+
 	public static String getString(JsonObject json, String name) {
 		JsonValue value = json.get(name);
 		return getString(value);

--- a/core/tern.core/src/tern/server/protocol/TernResultsProcessorsFactory.java
+++ b/core/tern.core/src/tern/server/protocol/TernResultsProcessorsFactory.java
@@ -34,6 +34,9 @@ import tern.server.protocol.type.TernTypeResultProcessor;
 
 public class TernResultsProcessorsFactory {
 
+	private TernResultsProcessorsFactory() {
+	}
+
 	public static <T extends ITernResultsCollector> void makeRequestAndProcess(
 			TernDoc doc, ITernServer server, T collector) throws TernException {
 		ITernResultProcessor<T> resultProcesor = TernResultsProcessorsFactory

--- a/core/tern.core/src/tern/server/protocol/completions/TernTypeHelper.java
+++ b/core/tern.core/src/tern/server/protocol/completions/TernTypeHelper.java
@@ -29,6 +29,9 @@ public class TernTypeHelper {
 	private static final String FUNCTION_START = "fn(";
 	private static final String FUNCTION_ARRAY_START = "[fn(";
 
+	private TernTypeHelper() {
+	}
+
 	/**
 	 * Returns true if the given type is fn() and false otherwise.
 	 * 

--- a/core/tern.core/src/tern/server/protocol/html/HtmlHelper.java
+++ b/core/tern.core/src/tern/server/protocol/html/HtmlHelper.java
@@ -16,6 +16,9 @@ package tern.server.protocol.html;
  */
 public class HtmlHelper {
 
+	private HtmlHelper() {
+	}
+
 	/**
 	 * Extract JS content from the given HTML content. The HTML elements are
 	 * replaced with space and JS content is kept. The JS content is declared

--- a/core/tern.core/src/tern/server/protocol/lint/TernLintResultHelper.java
+++ b/core/tern.core/src/tern/server/protocol/lint/TernLintResultHelper.java
@@ -14,6 +14,9 @@ public class TernLintResultHelper {
 	private static final String SEVERITY_FIELD = "severity";
 	private static final String TEXT_FIELD = "text";
 
+	private TernLintResultHelper() {
+	}
+
 	public static String getMessage(Object messageObject, TernLintQuery query, IJSONObjectHelper helper) {
 		return query.formatMessage(helper.getText(messageObject, MESSAGE_FIELD));
 	}

--- a/core/tern.core/src/tern/utils/DOMUtils.java
+++ b/core/tern.core/src/tern/utils/DOMUtils.java
@@ -28,6 +28,9 @@ import org.w3c.dom.Text;
  */
 public class DOMUtils {
 
+	private DOMUtils() {
+	}
+
 	/**
 	 * Returns the node value from the DOM NOde.
 	 * 

--- a/core/tern.core/src/tern/utils/ExtensionUtils.java
+++ b/core/tern.core/src/tern/utils/ExtensionUtils.java
@@ -34,6 +34,9 @@ public class ExtensionUtils {
 			.asList(new String[] { HTM_EXTENSION, HTML_EXTENSION,
 					JSP_EXTENSION, PHP_EXTENSION, JSF_EXTENSION });
 
+	private ExtensionUtils() {
+	}
+
 	public static String getFileExtension(String fileName) {
 		int index = fileName.lastIndexOf('.');
 		if (index == -1)

--- a/core/tern.core/src/tern/utils/IOUtils.java
+++ b/core/tern.core/src/tern/utils/IOUtils.java
@@ -145,7 +145,7 @@ public class IOUtils {
     /**
      * Instances should NOT be constructed in standard programming.
      */
-    public IOUtils() {
+    private IOUtils() {
         super();
     }
 

--- a/core/tern.core/src/tern/utils/StringUtils.java
+++ b/core/tern.core/src/tern/utils/StringUtils.java
@@ -28,6 +28,9 @@ public class StringUtils {
 
 	public static final String[] EMPTY_ARRAY = new String[0];
 
+	private StringUtils() {
+	}
+
 	public static boolean isEmpty(String str) {
 		return str == null || str.length() == 0;
 	}

--- a/core/tern.core/src/tern/utils/TernModuleHelper.java
+++ b/core/tern.core/src/tern/utils/TernModuleHelper.java
@@ -46,6 +46,9 @@ import tern.server.TernModuleInfo;
  */
 public class TernModuleHelper {
 
+	private TernModuleHelper() {
+	}
+
 	/**
 	 * Group the given list tern modules by {@link ITernModule#getType()}.
 	 * 

--- a/core/tern.core/src/tern/utils/ZipUtils.java
+++ b/core/tern.core/src/tern/utils/ZipUtils.java
@@ -28,6 +28,9 @@ public class ZipUtils {
 	private static final String JAR_EXTENSION = ".jar";
 	private static final String BIN_FOLDER = "/bin";
 
+	private ZipUtils() {
+	}
+
 	/**
 	 * Returns true if the given file is a zip file and false otherwise.
 	 * 

--- a/core/tern.server.nodejs/src/tern/server/nodejs/NodejsTernHelper.java
+++ b/core/tern.server.nodejs/src/tern/server/nodejs/NodejsTernHelper.java
@@ -59,8 +59,11 @@ public class NodejsTernHelper {
 
 	// tern uses UTF-8 encoding
 	private static final String UTF_8 = "UTF-8";
-	
-	public static JsonObject makeRequest(String baseURL, TernDoc doc,
+
+	public NodejsTernHelper() {
+	}
+
+	public static JsonObject makeRequest(String baseURL, TernDoc doc, 
 			boolean silent, List<IInterceptor> interceptors, ITernServer server)
 			throws IOException, TernException {
 		TernQuery query = doc.getQuery();

--- a/core/tern.server.nodejs/src/tern/server/nodejs/process/NPMProcessHelper.java
+++ b/core/tern.server.nodejs/src/tern/server/nodejs/process/NPMProcessHelper.java
@@ -33,6 +33,9 @@ public class NPMProcessHelper {
 	private static final String[] LINUX_NODE_PATHS = new String[] {
 			"/usr/local/bin/npm", "npm" };
 
+	private NPMProcessHelper() {
+	}
+
 	public static String getNPMPath(OS os) {
 		String path = getDefaultNPMPath(os);
 		if (path != null) {

--- a/core/tern.server.nodejs/src/tern/server/nodejs/process/NodejsProcessHelper.java
+++ b/core/tern.server.nodejs/src/tern/server/nodejs/process/NodejsProcessHelper.java
@@ -33,6 +33,9 @@ public class NodejsProcessHelper {
 	private static final String[] LINUX_NODE_PATHS = new String[] {
 			"/usr/local/bin/node", "node" };
 
+	private NodejsProcessHelper() {
+	}
+
 	public static String getNodejsPath(OS os) {
 		String path = getDefaultNodejsPath(os);
 		if (path != null) {

--- a/core/tern.server.nodejs/tests/tern/server/nodejs/RunCommand.java
+++ b/core/tern.server.nodejs/tests/tern/server/nodejs/RunCommand.java
@@ -9,6 +9,9 @@ import tern.server.protocol.TernDoc;
 
 public class RunCommand {
 
+	private RunCommand() {
+	}
+
 	public static void main(String[] args) throws IOException {
 
 		TernDoc doc = new TernDoc();

--- a/core/tern.server.nodejs/tests/tern/server/nodejs/SendBuffer.java
+++ b/core/tern.server.nodejs/tests/tern/server/nodejs/SendBuffer.java
@@ -8,6 +8,9 @@ import tern.server.protocol.TernDoc;
 
 public class SendBuffer {
 
+	private SendBuffer() {
+	}
+
 	public static void main(String[] args) throws IOException {
 
 		// {"files": [{"type": "full",

--- a/core/tern.server.nodejs/tests/tern/server/nodejs/Start.java
+++ b/core/tern.server.nodejs/tests/tern/server/nodejs/Start.java
@@ -7,6 +7,9 @@ import java.util.List;
 
 public class Start {
 
+	private Start() {
+	}
+
 	public static void main(String[] args) throws IOException, InterruptedException {
 		File nodejsTernFile = new File(".");
 		ProcessBuilder builder = new ProcessBuilder(createCommands(

--- a/core/tern.server.nodejs/tests/tern/server/nodejs/StartNodejsTernServer.java
+++ b/core/tern.server.nodejs/tests/tern/server/nodejs/StartNodejsTernServer.java
@@ -12,6 +12,9 @@ import tern.server.nodejs.process.PrintNodejsProcessListener;
 // http://localhost:12345/ping
 public class StartNodejsTernServer {
 
+	private StartNodejsTernServer() {
+	}
+
 	public static void main(String[] args) throws MalformedURLException,
 			IOException, InterruptedException {
 		File nodejsTernBaseDir = new File(".");

--- a/eclipse/linters/tern.eclipse.ide.linter.core/src/tern/eclipse/ide/linter/core/validation/TernValidationHelper.java
+++ b/eclipse/linters/tern.eclipse.ide.linter.core/src/tern/eclipse/ide/linter/core/validation/TernValidationHelper.java
@@ -23,7 +23,10 @@ import tern.server.protocol.lint.TernLintQuery;
 
 public class TernValidationHelper {
 
-	public static void validate(IResource resource, IIDETernProject ternProject, boolean needsLineNumber, boolean synch,
+	private TernValidationHelper() {
+	}
+
+	public static void validate(IResource resource, IIDETernProject ternProject, boolean needsLineNumber, boolean synch, 
 			boolean withFix, IReporter reporter, IValidator validator) {
 		ITernPlugin[] lintPlugins = ternProject.getLinters();
 		if (lintPlugins.length > 0) {

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/preferences/TernCorePreferenceConstants.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/preferences/TernCorePreferenceConstants.java
@@ -59,6 +59,10 @@ public class TernCorePreferenceConstants {
 	public static final String DEFAULT_TERN_MODULES = "defaultTernModules"; //$NON-NLS-1$
 	public static final String DEFAULT_TERN_MODULES_VALUE = getDefaultModules(); //$NON-NLS-1$
 
+
+	private TernCorePreferenceConstants() {
+	}
+
 	/**
 	 * Returns the tern modules to add to .tern-project when project is
 	 * converted to tern project.

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/utils/FileUtils.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/utils/FileUtils.java
@@ -23,6 +23,9 @@ public class FileUtils {
 
 	private static ILineOfOffsetProvider provider;
 
+	private FileUtils() {
+	}
+
 	/**
 	 * Set the line offset provider singleton.
 	 */

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/utils/PathUtils.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/utils/PathUtils.java
@@ -20,6 +20,9 @@ public class PathUtils {
 
 	private static final String SLASH_STAR = "/*";
 
+	private PathUtils() {
+	}
+
 	/**
 	 * Returns true if the given path belongs to the given container and false
 	 * otherwise.

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/IDENodejsProcessHelper.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/IDENodejsProcessHelper.java
@@ -33,6 +33,9 @@ public class IDENodejsProcessHelper {
 		}
 	}
 
+	private IDENodejsProcessHelper() {
+	}
+
 	public static String getNodejsPath() {
 		return NodejsProcessHelper.getNodejsPath(os);
 	}

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/TernNodejsCoreConstants.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/TernNodejsCoreConstants.java
@@ -35,4 +35,6 @@ public class TernNodejsCoreConstants {
 
 	public static final String NODEJS_TERN_REPOSITORY = "ternRepository"; //$NON-NLS-1$
 
+	private TernNodejsCoreConstants() {
+	}
 }

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/NodejsDebuggersManager.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/NodejsDebuggersManager.java
@@ -47,6 +47,9 @@ public class NodejsDebuggersManager {
 		debuggers = Collections.unmodifiableMap(debuggers);
 	}
 
+	private NodejsDebuggersManager() {
+	}
+
 	public static Collection<INodejsDebugger> getDebuggers() {
 		return debuggers.values();
 	}

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/launchConfigurations/NodejsCliFileHelper.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/launchConfigurations/NodejsCliFileHelper.java
@@ -35,6 +35,9 @@ public class NodejsCliFileHelper {
 
 	private static final String WORKSPACE_LOC = "workspace_loc";
 
+	private NodejsCliFileHelper() {
+	}
+
 	public static IFile getConfigFile(String param) throws NodejsCliFileConfigException, CoreException {
 		if (StringUtils.isEmpty(param)) {
 			throw new NodejsCliFileConfigException("Configuration file cannot be empty.");

--- a/eclipse/tern.eclipse.ide.tools.ui/src/tern/eclipse/ide/tools/internal/ui/console/TernRepositoryConsoleHelper.java
+++ b/eclipse/tern.eclipse.ide.tools.ui/src/tern/eclipse/ide/tools/internal/ui/console/TernRepositoryConsoleHelper.java
@@ -18,6 +18,9 @@ import tern.eclipse.ide.ui.console.LineType;
 
 public class TernRepositoryConsoleHelper {
 
+	private TernRepositoryConsoleHelper() {
+	}
+
 	public static void doAppendLine(final LineType lineType, final String line) {
 		TernRepositoryConsole console = TernRepositoryConsole.getConsole();
 		showConsole(console);

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/console/TernConsoleHelper.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/console/TernConsoleHelper.java
@@ -16,6 +16,9 @@ import org.eclipse.ui.console.IConsoleManager;
 
 public class TernConsoleHelper {
 
+	private TernConsoleHelper() {
+	}
+
 	public static void showConsole(TernConsole console) {
 		if (console != null) {
 			IConsoleManager manager = ConsolePlugin.getDefault()

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/preferences/TernUIPreferenceConstants.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/internal/ui/preferences/TernUIPreferenceConstants.java
@@ -29,4 +29,6 @@ public class TernUIPreferenceConstants {
 	public static final String OMIT_OBJECT_PROTOTYPE_CONTENT_ASSIST = "omitObjectPrototype"; //$NON-NLS-1$
 	public static final String GUESS_CONTENT_ASSIST = "guess"; //$NON-NLS-1$
 
+	private TernUIPreferenceConstants() {
+	}
 }

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/JavaWordFinder.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/JavaWordFinder.java
@@ -17,7 +17,10 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 
 public class JavaWordFinder {
-	
+
+	private JavaWordFinder() {
+	}
+
 	public static IRegion findWord(IDocument document, int offset) {
 
 		int start= -2;

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/contentassist/TernCompletionsQueryFactory.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/contentassist/TernCompletionsQueryFactory.java
@@ -25,7 +25,10 @@ import tern.server.protocol.completions.TernCompletionsQuery;
 
 public class TernCompletionsQueryFactory {
 
-	public static TernCompletionsQuery createQuery(IProject project,
+	private TernCompletionsQueryFactory() {
+	}
+
+	public static TernCompletionsQuery createQuery(IProject project, 
 			String file, int pos) {
 		TernCompletionsQuery query = new TernCompletionsQuery(file, pos);
 

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/BrowserSupport.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/BrowserSupport.java
@@ -28,6 +28,9 @@ import tern.eclipse.ide.internal.ui.Trace;
 
 public class BrowserSupport {
 
+	private BrowserSupport() {
+	}
+
 	/**
 	 * Opens the given url in the browser as choosen in the preferences.
 	 * 

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/DialogUtils.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/DialogUtils.java
@@ -31,7 +31,10 @@ import tern.utils.StringUtils;
 
 public class DialogUtils {
 
-	public static IResource openFolderDialog(String initialFolder,
+	private DialogUtils() {
+	}
+
+	public static IResource openFolderDialog(String initialFolder, 
 			IProject project, boolean showAllProjects, Shell shell) {
 		SelectionDialog dialog = createFolderDialog(initialFolder, project,
 				showAllProjects, shell);

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/EditorUtils.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/EditorUtils.java
@@ -47,6 +47,9 @@ import tern.utils.StringUtils;
  */
 public class EditorUtils {
 
+	private EditorUtils() {
+	}
+
 	public static IEditorPart openInEditor(IFile file, int start, int length,
 			boolean activate) {
 		IEditorPart editor = null;

--- a/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/HTMLTernPrinter.java
+++ b/eclipse/tern.eclipse.ide.ui/src/tern/eclipse/ide/ui/utils/HTMLTernPrinter.java
@@ -47,8 +47,11 @@ public class HTMLTernPrinter {
 	private static String fgStyleSheet;
 
 	private static RGB colorInfoBackround = null;
-	private static RGB colorInfoForeground = null; 
-	
+	private static RGB colorInfoForeground = null;
+
+	private HTMLTernPrinter() {
+	}
+
 	public static void setColorInfoBackround(RGB colorInfoBackround) {
 		HTMLTernPrinter.colorInfoBackround = colorInfoBackround;
 	}

--- a/eclipse/tern.eclipse/src/tern/eclipse/jface/images/TernImagesRegistry.java
+++ b/eclipse/tern.eclipse/src/tern/eclipse/jface/images/TernImagesRegistry.java
@@ -77,6 +77,9 @@ public class TernImagesRegistry {
 				TernImagesRegistry.class, "import.png"));
 	}
 
+	private TernImagesRegistry() {
+	}
+
 	/**
 	 * Returns the image from the image registry with the given key.
 	 * 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.