### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/core/tern.core/src/tern/server/TernModuleInfo.java
+++ b/core/tern.core/src/tern/server/TernModuleInfo.java
@@ -73,6 +73,15 @@ public class TernModuleInfo implements ITernModuleInfo {
 		return false;
 	}
 
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		result = 31 * result + (type != null ? type.hashCode() : 0);
+		result = 31 * result + (version != null ? version.hashCode() : 0);
+		return result;
+	}
+
 	private boolean equals(Object o1, Object o2) {
 		if (o1 == null) {
 			return (o2 == null);

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/resources/TernDocumentFile.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/resources/TernDocumentFile.java
@@ -67,4 +67,11 @@ public class TernDocumentFile extends IDETernFile implements ITernFile {
 		TernDocumentFile doc = (TernDocumentFile) obj;
 		return doc.document.equals(this.document) && doc.getFile().equals(getFile());
 	}
+
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (document != null ? document.hashCode() : 0);
+		return result;
+	}
 }

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/resources/IDETernProject.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/resources/IDETernProject.java
@@ -529,6 +529,19 @@ public class IDETernProject extends TernProject implements IIDETernProject, ITer
 		return super.equals(value);
 	}
 
+	@Override
+	public int hashCode() {
+		int result = super.hashCode();
+		result = 31 * result + (project != null ? project.hashCode() : 0);
+		result = 31 * result + (ternServer != null ? ternServer.hashCode() : 0);
+		result = 31 * result + (scriptPaths != null ? scriptPaths.hashCode() : 0);
+		result = 31 * result + (sortedScriptPaths != null ? sortedScriptPaths.hashCode() : 0);
+		result = 31 * result + (data != null ? data.hashCode() : 0);
+		result = 31 * result + (listeners != null ? listeners.hashCode() : 0);
+		result = 31 * result + (workingCopy != null ? workingCopy.hashCode() : 0);
+		return result;
+	}
+
 	/**
 	 * Returns the script path instance from the given path and null otherwise.
 	 * 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “ equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.