### PR TITLE
Release Tern project file after loading

### DIFF
--- a/core/tern.core/src/tern/resources/TernProject.java
+++ b/core/tern.core/src/tern/resources/TernProject.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -514,10 +515,16 @@ public class TernProject extends JsonObject implements ITernProject {
 	 */
 	protected void doLoad() throws IOException {
 		if (ternProjectFile.exists()) {
+			Reader reader = null;
 			try {
-				JsonHelper.readFrom(new FileReader(ternProjectFile), this);
+				reader = new FileReader(ternProjectFile);
+				JsonHelper.readFrom(reader, this);
 			} catch (ParseException e) {
 				throw new IOException(e);
+			} finally {
+				if (reader != null) {
+					IOUtils.closeQuietly(reader);
+				}
 			}
 		} else {
 			createEmptyTernProjectFile();


### PR DESCRIPTION
As specified in issue #401 , currently it is impossible to delete an Eclipse project with Tern nature because the '.tern-project' file is in use.

This commit fixes this issue by properly releasing the Tern project file FileReader after loading.
