### PR TITLE
More generic working dir calculation with ITernProject.

### DIFF
--- a/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/src/tern/eclipse/ide/debugger/nodeclipse/NodeclipseDebugger.java
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/src/tern/eclipse/ide/debugger/nodeclipse/NodeclipseDebugger.java
@@ -13,7 +13,6 @@ package tern.eclipse.ide.debugger.nodeclipse;
 import java.io.File;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 
 import tern.TernException;
 import tern.eclipse.ide.server.nodejs.core.debugger.AbstractNodejsDebuggerDelegate;
@@ -31,7 +30,7 @@ public class NodeclipseDebugger extends AbstractNodejsDebuggerDelegate {
 	}
 
 	@Override
-	public INodejsProcess createProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath)
+	public INodejsProcess createProcess(IFile jsFile, File workingDir, File nodejsInstallPath)
 			throws TernException {
 		return new NodeclipseNodejsDebugProcess(jsFile, workingDir, nodejsInstallPath, getLaunchId());
 	}

--- a/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/src/tern/eclipse/ide/debugger/nodeclipse/NodeclipseNodejsDebugProcess.java
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/src/tern/eclipse/ide/debugger/nodeclipse/NodeclipseNodejsDebugProcess.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.util.Collections;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -31,7 +30,7 @@ import tern.eclipse.ide.server.nodejs.core.debugger.AbstractNodejsDebugProcess;
  */
 public class NodeclipseNodejsDebugProcess extends AbstractNodejsDebugProcess {
 
-	public NodeclipseNodejsDebugProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath,
+	public NodeclipseNodejsDebugProcess(IFile jsFile, File workingDir, File nodejsInstallPath,
 			String launchConfigId) throws TernException {
 		super(jsFile, workingDir, nodejsInstallPath, launchConfigId);
 	}

--- a/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/src/tern/eclipse/ide/debugger/webclipse/WebclipseDebugger.java
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/src/tern/eclipse/ide/debugger/webclipse/WebclipseDebugger.java
@@ -13,7 +13,6 @@ package tern.eclipse.ide.debugger.webclipse;
 import java.io.File;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 
 import tern.TernException;
 import tern.eclipse.ide.server.nodejs.core.debugger.AbstractNodejsDebuggerDelegate;
@@ -31,7 +30,7 @@ public class WebclipseDebugger extends AbstractNodejsDebuggerDelegate {
 	}
 
 	@Override
-	public INodejsProcess createProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath)
+	public INodejsProcess createProcess(IFile jsFile, File workingDir, File nodejsInstallPath)
 			throws TernException {
 		return new WebclipseNodejsDebugProcess(jsFile, workingDir, nodejsInstallPath, getLaunchId());
 	}

--- a/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/src/tern/eclipse/ide/debugger/webclipse/WebclipseNodejsDebugProcess.java
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/src/tern/eclipse/ide/debugger/webclipse/WebclipseNodejsDebugProcess.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.util.Collections;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -38,7 +37,7 @@ import tern.eclipse.ide.server.nodejs.core.debugger.AbstractNodejsDebugProcess;
  */
 public class WebclipseNodejsDebugProcess extends AbstractNodejsDebugProcess {
 
-	public WebclipseNodejsDebugProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath,
+	public WebclipseNodejsDebugProcess(IFile jsFile, File workingDir, File nodejsInstallPath,
 			String launchConfigId) throws TernException {
 		super(jsFile, workingDir, nodejsInstallPath, launchConfigId);
 	}

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernServerFactory.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernServerFactory.java
@@ -10,6 +10,7 @@
  */
 package tern.eclipse.ide.core;
 
+import tern.ITernProject;
 import tern.server.ITernServer;
 
 /**
@@ -25,6 +26,6 @@ public interface ITernServerFactory {
 	 * @return an instance of tern server by using the given tern project.
 	 * @throws Exception
 	 */
-	ITernServer create(IIDETernProject project) throws Exception;
+	ITernServer create(ITernProject project) throws Exception;
 
 }

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernServerType.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/core/ITernServerType.java
@@ -10,6 +10,7 @@
  */
 package tern.eclipse.ide.core;
 
+import tern.ITernProject;
 import tern.server.ITernServer;
 
 /**
@@ -45,7 +46,7 @@ public interface ITernServerType {
 	 * @return an instance of tern server by using the given tern project.
 	 * @throws Exception
 	 */
-	ITernServer createServer(IIDETernProject project) throws Exception;
+	ITernServer createServer(ITernProject project) throws Exception;
 
 	/**
 	 * Dispose the whole tern server created.

--- a/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernServerType.java
+++ b/eclipse/tern.eclipse.ide.core/src/tern/eclipse/ide/internal/core/TernServerType.java
@@ -16,7 +16,7 @@ import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 
-import tern.eclipse.ide.core.IIDETernProject;
+import tern.ITernProject;
 import tern.eclipse.ide.core.ITernServerFactory;
 import tern.eclipse.ide.core.ITernServerType;
 import tern.server.ITernServer;
@@ -86,7 +86,7 @@ public class TernServerType implements ITernServerType {
 	}
 
 	@Override
-	public ITernServer createServer(IIDETernProject project) throws Exception {
+	public ITernServer createServer(ITernProject project) throws Exception {
 		ITernServer server = getFactory().create(project);
 		server.addServerListener(serverListener);
 		return server;

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/AbstractNodejsDebugProcess.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/AbstractNodejsDebugProcess.java
@@ -15,9 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
@@ -40,17 +38,15 @@ import tern.utils.TernModuleHelper;
  */
 public abstract class AbstractNodejsDebugProcess extends AbstractNodejsProcess {
 
-	private final IProject workingDir;
 	private final IFile jsFile; // (ex : bin/tern filde)
 	private final String launchConfigId;
 	private final List<StreamProcessor> streamProcessors;
 
 	protected ILaunch launch;
 
-	public AbstractNodejsDebugProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath, String launchConfigId)
+	public AbstractNodejsDebugProcess(IFile jsFile, File workingDir, File nodejsInstallPath, String launchConfigId)
 			throws TernException {
-		super(nodejsInstallPath, workingDir.getLocation().toFile());
-		this.workingDir = workingDir;
+		super(nodejsInstallPath, workingDir);
 		this.jsFile = jsFile;
 		this.launchConfigId = launchConfigId;
 		this.streamProcessors = new ArrayList<AbstractNodejsDebugProcess.StreamProcessor>();
@@ -61,7 +57,7 @@ public abstract class AbstractNodejsDebugProcess extends AbstractNodejsProcess {
 	}
 
 	protected String getWorkingDir() {
-		return NodejsCliFileHelper.getWorkspaceLoc(workingDir);
+		return NodejsCliFileHelper.getWorkspaceLoc(getProjectDir());
 	}
 
 	@Override

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/INodejsDebuggerDelegate.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/INodejsDebuggerDelegate.java
@@ -13,7 +13,6 @@ package tern.eclipse.ide.server.nodejs.core.debugger;
 import java.io.File;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 
 import tern.TernException;
 import tern.server.nodejs.process.INodejsProcess;
@@ -55,6 +54,6 @@ public interface INodejsDebuggerDelegate {
 	 *         working directory by using the given node install.
 	 * @throws TernException
 	 */
-	INodejsProcess createProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath) throws TernException;
+	INodejsProcess createProcess(IFile jsFile, File workingDir, File nodejsInstallPath) throws TernException;
 
 }

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/NodejsDebuggersManager.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/NodejsDebuggersManager.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.Platform;
@@ -124,7 +123,7 @@ public class NodejsDebuggersManager {
 		}
 		
 		@Override
-		public INodejsProcess createProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath)
+		public INodejsProcess createProcess(IFile jsFile, File workingDir, File nodejsInstallPath)
 				throws TernException {
 			return delegate.createProcess(jsFile, workingDir, nodejsInstallPath);
 		}

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/launchConfigurations/AbstractNodejsCliFileLauncher.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/launchConfigurations/AbstractNodejsCliFileLauncher.java
@@ -82,7 +82,7 @@ public abstract class AbstractNodejsCliFileLauncher implements INodejsLaunchConf
 	}
 
 	public void start() throws TernException {
-		INodejsProcess process = debugger.createProcess(cliFile, configFile.getProject(), nodeInstallPath);
+		INodejsProcess process = debugger.createProcess(cliFile, configFile.getProject().getLocation().toFile(), nodeInstallPath);
 		process.setLaunchConfiguration(this);
 		process.start();
 	}

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/launchConfigurations/NodejsCliFileHelper.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/debugger/launchConfigurations/NodejsCliFileHelper.java
@@ -103,6 +103,19 @@ public class NodejsCliFileHelper {
 		throw new NodejsCliFileConfigException("Cannot find tern debugger with id" + debuggerId);
 	}
 
+	public static String getWorkspaceLoc(File file) {
+		IResource[] res;
+		if (file.isDirectory()) {
+			res = ResourcesPlugin.getWorkspace().getRoot().findContainersForLocationURI(file.toURI());
+		} else {
+			res = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(file.toURI());
+		}
+		if (res != null && res.length > 0) {
+			return getWorkspaceLoc(res[0]);
+		}
+		return file.toString();
+	}
+	
 	public static String getWorkspaceLoc(IResource file) {
 		return VariablesPlugin.getDefault().getStringVariableManager().generateVariableExpression(WORKSPACE_LOC,
 				file.getFullPath().toString());

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/TernNodejsServerFactory.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/TernNodejsServerFactory.java
@@ -16,7 +16,7 @@ import java.io.File;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 
-import tern.eclipse.ide.core.IIDETernProject;
+import tern.ITernProject;
 import tern.eclipse.ide.core.ITernServerFactory;
 import tern.eclipse.ide.server.nodejs.core.debugger.INodejsDebugger;
 import tern.eclipse.ide.server.nodejs.core.debugger.NodejsDebuggersManager;
@@ -29,7 +29,7 @@ import tern.server.nodejs.NodejsTernServer;
 public class TernNodejsServerFactory implements ITernServerFactory {
 
 	@Override
-	public ITernServer create(IIDETernProject project) throws Exception {
+	public ITernServer create(ITernProject project) throws Exception {
 		NodejsTernServer server;
 		if (isRemoteAccess()) {
 			server = new NodejsTernServer(project, getRemotePort()) {
@@ -52,7 +52,7 @@ public class TernNodejsServerFactory implements ITernServerFactory {
 					&& !ternServerFile.getProject().equals(
 							project.getAdapter(IProject.class))) {
 				server = new NodejsTernServer(project, debugger.createProcess(
-						ternServerFile, project.getProject(), installPath)){
+						ternServerFile, project.getProjectDir(), installPath)){
 					@Override
 					protected void onError(String message, Throwable e) {
 						Trace.trace(Trace.SEVERE, message, e);

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/debugger/ProgramNodejsDebugProcess.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/debugger/ProgramNodejsDebugProcess.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -32,9 +31,10 @@ import tern.server.nodejs.process.NodejsProcessException;
 /**
  * Program debugger process implementation.
  */
+@SuppressWarnings("restriction")
 public class ProgramNodejsDebugProcess extends AbstractNodejsDebugProcess {
 
-	public ProgramNodejsDebugProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath, String launchConfigId)
+	public ProgramNodejsDebugProcess(IFile jsFile, File workingDir, File nodejsInstallPath, String launchConfigId)
 			throws TernException {
 		super(jsFile, workingDir, nodejsInstallPath, launchConfigId);
 	}
@@ -80,7 +80,7 @@ public class ProgramNodejsDebugProcess extends AbstractNodejsDebugProcess {
 			}
 		});
 
-		launch = workingCopy.launch("run", null); //only works in run mode
+		launch = workingCopy.launch("run", null); //only works in run mode //$NON-NLS-1$
 
 		// setup std and err listeners
 		for (IProcess process : launch.getProcesses()) {
@@ -96,7 +96,7 @@ public class ProgramNodejsDebugProcess extends AbstractNodejsDebugProcess {
 		StringBuilder args = new StringBuilder();
 		args.append(NodejsCliFileHelper.getWorkspaceLoc(getJsFile()));
 		for (String arg : createNodejsArgs()) {
-			args.append(" ");
+			args.append(" "); //$NON-NLS-1$
 			args.append(arg);
 		}
 		return args.toString();

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/debugger/ProgramNodejsDebugger.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/debugger/ProgramNodejsDebugger.java
@@ -13,7 +13,6 @@ package tern.eclipse.ide.server.nodejs.internal.core.debugger;
 import java.io.File;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 
 import tern.TernException;
 import tern.eclipse.ide.server.nodejs.core.debugger.AbstractNodejsDebuggerDelegate;
@@ -31,7 +30,7 @@ public class ProgramNodejsDebugger extends AbstractNodejsDebuggerDelegate {
 	}
 
 	@Override
-	public INodejsProcess createProcess(IFile jsFile, IProject workingDir, File nodejsInstallPath)
+	public INodejsProcess createProcess(IFile jsFile, File workingDir, File nodejsInstallPath)
 			throws TernException {
 		return new ProgramNodejsDebugProcess(jsFile, workingDir, nodejsInstallPath, getLaunchId());
 	}

--- a/eclipse/tern.eclipse.ide.server.rhino.core/src/tern/eclipse/ide/server/rhino/internal/core/TernRhinoServerFactory.java
+++ b/eclipse/tern.eclipse.ide.server.rhino.core/src/tern/eclipse/ide/server/rhino/internal/core/TernRhinoServerFactory.java
@@ -10,7 +10,7 @@
  */
 package tern.eclipse.ide.server.rhino.internal.core;
 
-import tern.eclipse.ide.core.IIDETernProject;
+import tern.ITernProject;
 import tern.eclipse.ide.core.ITernServerFactory;
 import tern.server.ITernServer;
 import tern.server.rhino.RhinoTernServer;
@@ -18,7 +18,7 @@ import tern.server.rhino.RhinoTernServer;
 public class TernRhinoServerFactory implements ITernServerFactory {
 
 	@Override
-	public ITernServer create(IIDETernProject project) throws Exception {
+	public ITernServer create(ITernProject project) throws Exception {
 		return new RhinoTernServer(project);
 	}
 


### PR DESCRIPTION
In my project I used custom ITernProject for some very specific use cases and the code benefits from using ITernProject API instead of IIDETernProject. I have reverted some of your changes to API and yet kept the intended behaviour - provide workspace relative paths when possible. Please let me know if this works for you!