### PR TITLE
Extension of the install provider to accept a class

### DIFF
--- a/eclipse/tern.eclipse.ide.server.nodejs.core/schema/nodeJSInstalls.exsd
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/schema/nodeJSInstalls.exsd
@@ -45,34 +45,51 @@
    </element>
 
    <element name="install">
+      <annotation>
+         <documentation>
+            This extension point allows developers to specify their own Node.js install location. This can be done in two ways:
+&lt;ol&gt;
+&lt;li&gt;A developer can implement &lt;i&gt;INodejsInstallProvider&lt;/i&gt; interface to programmatically tell Tern.java where Node.js is installed. This is useful for situations where you need to do some computations before specifying the location path.
+&lt;li&gt;Bundle Node.js in the extending bundle and specify the location of the Node program relative to the bundle. If you ship Node.js in your bundle in the form of a ZIP archive, make sure you specify the ZIP location withing the bundle using the &lt;i&gt;zip&lt;/i&gt; attribute. 
+&lt;/ol&gt;
+         </documentation>
+      </annotation>
       <complexType>
-         <sequence>
-         </sequence>
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  The id of this Nodejs install. Each known Nodejs install has a distinct id. Ids are intended to be used internally as keys; they are not intended to be shown to end users.
                </documentation>
             </annotation>
          </attribute>
          <attribute name="name" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  The displayable name for this Nodejs install.
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="path" type="string" use="required">
+         <attribute name="class" type="string">
             <annotation>
                <documentation>
-                  
+                  Provides a way to programmatically specify the install location of a Node.js within the system. This allows extenders to compute install locations that are not in the extending bundle. Extenders must implement &lt;i&gt;tern.eclipse.ide.server.nodejs.core.INodejsInstallProvider&lt;/i&gt; interface.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":tern.eclipse.ide.server.nodejs.core.INodejsInstallProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="path" type="string">
+            <annotation>
+               <documentation>
+                  The file path for this Nodejs install.
                </documentation>
             </annotation>
          </attribute>
          <attribute name="zip" type="string">
             <annotation>
                <documentation>
-                  
+                  If path doesn&apos;t exist, specify a ZIP archive within the bundle that contains the node program. This extension will unzip it and look for the node path.
                </documentation>
             </annotation>
          </attribute>

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/INodejsInstallProvider.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/core/INodejsInstallProvider.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright (c) 2016 Angelo ZERR, IBM
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Victor Sosa <sosah.victor@gmail.com>- initial API and implementation
+ */
+package tern.eclipse.ide.server.nodejs.core;
+
+import java.io.File;
+
+/**
+ * Provides a way to programmatically specify the install location of a Node.js
+ * within the system.
+ * 
+ * @author <a href="mailto:sosah.victor@gmail.com">sosah.victor@gmail.com</a>
+ *
+ */
+public interface INodejsInstallProvider {
+	
+	/**
+	 * Location where this Node.js is installed
+	 * 
+	 * @return Node.js install location
+	 */
+	File getPath();
+}


### PR DESCRIPTION
Developers can programmatically specify their own Node.js install location. 
This is suggested in issue#434