### PR TITLE
JBDS-4132 Could not load nodeJSInstall: node-v0.10.22-linux-x86_64

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>tern.java</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>core</artifactId>
 	<packaging>pom</packaging>

--- a/core/tern.core.tests/META-INF/MANIFEST.MF
+++ b/core/tern.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests2
 Bundle-SymbolicName: tern.core.tests
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.core,
  tern.server.nodejs,

--- a/core/tern.core.tests/pom.xml
+++ b/core/tern.core.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>tern.core.tests</artifactId>
 </project>

--- a/core/tern.core/META-INF/MANIFEST.MF
+++ b/core/tern.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.core
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: tern,
  tern.angular,

--- a/core/tern.core/pom.xml
+++ b/core/tern.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/core/tern.server.j2v8/META-INF/MANIFEST.MF
+++ b/core/tern.server.j2v8/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.server.j2v8;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.core
 Bundle-ClassPath: .

--- a/core/tern.server.j2v8/pom.xml
+++ b/core/tern.server.j2v8/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/core/tern.server.nashorn/META-INF/MANIFEST.MF
+++ b/core/tern.server.nashorn/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.server.nashorn;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: tern.core
 Bundle-ClassPath: .

--- a/core/tern.server.nashorn/pom.xml
+++ b/core/tern.server.nashorn/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/core/tern.server.nodejs/META-INF/MANIFEST.MF
+++ b/core/tern.server.nodejs/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.server.nodejs;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.core
 Bundle-ClassPath: .

--- a/core/tern.server.nodejs/pom.xml
+++ b/core/tern.server.nodejs/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/core/tern.server.rhino/META-INF/MANIFEST.MF
+++ b/core/tern.server.rhino/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.server.rhino
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: org.mozilla.javascript;bundle-version="1.7.4",
  com.eclipsesource.json;version="[0.9.4,0.9.5)"

--- a/core/tern.server.rhino/pom.xml
+++ b/core/tern.server.rhino/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/core/tern.websocket.provider/META-INF/MANIFEST.MF
+++ b/core/tern.websocket.provider/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.websocket.provider;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Activator: tern.websocket.provider.internal.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: javax.websocket,

--- a/core/tern.websocket.provider/pom.xml
+++ b/core/tern.websocket.provider/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/core/ternjs/META-INF/MANIFEST.MF
+++ b/core/ternjs/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: ternjs;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Eclipse-BundleShape: dir
 Import-Package: org.osgi.framework
 Export-Package: ternjs

--- a/core/ternjs/pom.xml
+++ b/core/ternjs/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/debuggers/pom.xml
+++ b/eclipse/debuggers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>eclipse</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>debuggers</artifactId>
   <packaging>pom</packaging>

--- a/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/META-INF/MANIFEST.MF
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.debugger.nodeclipse;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/pom.xml
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.nodeclipse/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>debuggers</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/META-INF/MANIFEST.MF
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.debugger.webclipse;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/pom.xml
+++ b/eclipse/debuggers/tern.eclipse.ide.debugger.webclipse/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>debuggers</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/embed/pom.xml
+++ b/eclipse/embed/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>eclipse</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>embed</artifactId>
   <packaging>pom</packaging>

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86/META-INF/MANIFEST.MF
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.eclipse.ide.server.nodejs.core;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86/pom.xml
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>embed</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/META-INF/MANIFEST.MF
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.eclipse.ide.server.nodejs.core;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/pom.xml
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>embed</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern.eclipse.ide.server.nodejs.embed.linux.gtk.x86_64</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.macosx.cocoa.x86_64/META-INF/MANIFEST.MF
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.macosx.cocoa.x86_64/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.nodejs.embed.macosx.cocoa.x86_64;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.eclipse.ide.server.nodejs.core;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.macosx.cocoa.x86_64/pom.xml
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.macosx.cocoa.x86_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>embed</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern.eclipse.ide.server.nodejs.embed.macosx.cocoa.x86_64</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86/META-INF/MANIFEST.MF
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.nodejs.embed.win32.win32.x86;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.eclipse.ide.server.nodejs.core;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86/pom.xml
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>embed</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>tern.eclipse.ide.server.nodejs.embed.win32.win32.x86</artifactId>
 	<build>

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86_64/META-INF/MANIFEST.MF
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86_64/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.nodejs.embed.win32.win32.x86_64;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: tern.eclipse.ide.server.nodejs.core;bundle-version="0.2.0"
 Bundle-ActivationPolicy: lazy

--- a/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86_64/pom.xml
+++ b/eclipse/embed/tern.eclipse.ide.server.nodejs.embed.win32.win32.x86_64/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>embed</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>tern.eclipse.ide.server.nodejs.embed.win32.win32.x86_64</artifactId>
 	<build>

--- a/eclipse/jsdt/pom.xml
+++ b/eclipse/jsdt/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>eclipse</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>jsdt</artifactId>
   <packaging>pom</packaging>

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.core/META-INF/MANIFEST.MF
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.jsdt.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.jsdt.ui,

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.core/pom.xml
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>jsdt</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/META-INF/MANIFEST.MF
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.jsdt.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.jsdt.ui,

--- a/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/pom.xml
+++ b/eclipse/jsdt/tern.eclipse.ide.jsdt.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>jsdt</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/pom.xml
+++ b/eclipse/linters/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>eclipse</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>linters</artifactId>
   <packaging>pom</packaging>

--- a/eclipse/linters/tern.eclipse.ide.linter.core/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/linters/tern.eclipse.ide.linter.core/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.eslint.core/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.eslint.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.eslint.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/linters/tern.eclipse.ide.linter.eslint.core/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.eslint.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.eslint.ui/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.eslint.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.eslint.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/linters/tern.eclipse.ide.linter.eslint.ui/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.eslint.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.jscs.core/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.jscs.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.jscs.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/linters/tern.eclipse.ide.linter.jscs.core/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.jscs.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.jscs.ui/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.jscs.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.jscs.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/linters/tern.eclipse.ide.linter.jscs.ui/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.jscs.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.jshint.core/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.jshint.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.jshint.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/linters/tern.eclipse.ide.linter.jshint.core/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.jshint.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.jshint.ui/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.jshint.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.jshint.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/linters/tern.eclipse.ide.linter.jshint.ui/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.jshint.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.lint.core/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.lint.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.lint.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/linters/tern.eclipse.ide.linter.lint.core/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.lint.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.lint.ui/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.lint.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.lint.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/linters/tern.eclipse.ide.linter.lint.ui/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.lint.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/linters/tern.eclipse.ide.linter.ui/META-INF/MANIFEST.MF
+++ b/eclipse/linters/tern.eclipse.ide.linter.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.linter.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/linters/tern.eclipse.ide.linter.ui/pom.xml
+++ b/eclipse/linters/tern.eclipse.ide.linter.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>linters</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>tern.java</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>eclipse</artifactId>
 	<packaging>pom</packaging>

--- a/eclipse/tern.eclipse.ide.core/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/eclipse/tern.eclipse.ide.core/pom.xml
+++ b/eclipse/tern.eclipse.ide.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/tern.eclipse.ide.server.j2v8.core/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.server.j2v8.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.j2v8.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.nodejs.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core,

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/pom.xml
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/NodejsInstall.java
+++ b/eclipse/tern.eclipse.ide.server.nodejs.core/src/tern/eclipse/ide/server/nodejs/internal/core/NodejsInstall.java
@@ -13,13 +13,16 @@ package tern.eclipse.ide.server.nodejs.internal.core;
 import java.io.File;
 import java.io.IOException;
 
+import org.eclipse.core.internal.runtime.InternalPlatform;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
 import tern.eclipse.ide.server.nodejs.core.INodejsInstall;
 import tern.utils.ZipUtils;
 
+@SuppressWarnings("restriction")
 public class NodejsInstall implements INodejsInstall {
 
 	private final String id;
@@ -39,23 +42,31 @@ public class NodejsInstall implements INodejsInstall {
 		String pluginId = element.getNamespaceIdentifier();
 		String path = element.getAttribute("path");
 		if (path != null && path.length() > 0) {
-			File baseDir = FileLocator.getBundleFile(Platform
+			File bundleDir = FileLocator.getBundleFile(Platform
 					.getBundle(pluginId));
-			this.path = new File(baseDir, path);
+			
+			IPath stateLocationPath = InternalPlatform.getDefault().getStateLocation(Platform
+					.getBundle(pluginId), true);
+			
+			if (stateLocationPath != null) {
+				File baseDir = stateLocationPath.toFile();
 
-			// check if path exists, if it doesn't look for zip
-			if (!this.path.exists()) {
-				String zip = element.getAttribute("zip");
-
-				File zipFile = new File(baseDir, zip);
-
-				if (zipFile.exists()) {
-					if (zipFile.getName().toLowerCase().endsWith(".zip")) {
-						ZipUtils.extract(zipFile, baseDir);
-					}
-
-					if(this.path.exists()) {
-						this.path.setExecutable(true);
+				this.path = new File(baseDir, path);
+	
+				// check if path exists, if it doesn't look for zip
+				if (!this.path.exists()) {
+					String zip = element.getAttribute("zip");
+	
+					File zipFile = new File(bundleDir, zip);
+	
+					if (zipFile.exists()) {
+						if (zipFile.getName().toLowerCase().endsWith(".zip")) {
+							ZipUtils.extract(zipFile, baseDir);
+						}
+	
+						if(this.path.exists()) {
+							this.path.setExecutable(true);
+						}
 					}
 				}
 			}

--- a/eclipse/tern.eclipse.ide.server.nodejs.ui/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.server.nodejs.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.nodejs.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/tern.eclipse.ide.server.nodejs.ui/pom.xml
+++ b/eclipse/tern.eclipse.ide.server.nodejs.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/tern.eclipse.ide.server.rhino.core/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.server.rhino.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.server.rhino.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.core;bundle-version="0.2.0",

--- a/eclipse/tern.eclipse.ide.server.rhino.core/pom.xml
+++ b/eclipse/tern.eclipse.ide.server.rhino.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/tern.eclipse.ide.tools.core/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.tools.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.tools.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.core,

--- a/eclipse/tern.eclipse.ide.tools.core/pom.xml
+++ b/eclipse/tern.eclipse.ide.tools.core/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/tern.eclipse.ide.tools.ui/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.tools.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.tools.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  tern.eclipse.ide.tools.core,

--- a/eclipse/tern.eclipse.ide.tools.ui/pom.xml
+++ b/eclipse/tern.eclipse.ide.tools.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/tern.eclipse.ide.ui/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse.ide.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.ide.ui;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/eclipse/tern.eclipse.ide.ui/pom.xml
+++ b/eclipse/tern.eclipse.ide.ui/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/eclipse/tern.eclipse/META-INF/MANIFEST.MF
+++ b/eclipse/tern.eclipse/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.swt;bundle-version="3.7.0",
  org.eclipse.jface;bundle-version="3.7.0",

--- a/eclipse/tern.eclipse/pom.xml
+++ b/eclipse/tern.eclipse/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>eclipse</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<groupId>fr.opensagres.js</groupId>
 	<artifactId>tern.java</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/tern.eclipse.swt.samples.java8/META-INF/MANIFEST.MF
+++ b/samples/tern.eclipse.swt.samples.java8/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.swt.samples.java8
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.swt;bundle-version="3.7.0",
  org.eclipse.jface;bundle-version="3.7.0",

--- a/samples/tern.eclipse.swt.samples/META-INF/MANIFEST.MF
+++ b/samples/tern.eclipse.swt.samples/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: tern.eclipse.swt.samples
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.swt;bundle-version="3.7.0",
  org.eclipse.jface;bundle-version="3.7.0",

--- a/samples/ternModuleInstalls/META-INF/MANIFEST.MF
+++ b/samples/ternModuleInstalls/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: ternModuleInstalls;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources

--- a/samples/ternNatureAdapters/META-INF/MANIFEST.MF
+++ b/samples/ternNatureAdapters/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: ternNatureAdapters;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/update-site/pom.xml
+++ b/update-site/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>tern.java</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>update-site</artifactId>
 	<packaging>pom</packaging>

--- a/update-site/tern-feature/feature.xml
+++ b/update-site/tern-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tern-feature"
       label="%featureName"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.0.qualifier">

--- a/update-site/tern-feature/pom.xml
+++ b/update-site/tern-feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>update-site</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern-feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/update-site/tern-jsdt-feature/feature.xml
+++ b/update-site/tern-jsdt-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tern-jsdt-feature"
       label="%featureName"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.0.qualifier">

--- a/update-site/tern-jsdt-feature/pom.xml
+++ b/update-site/tern-jsdt-feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>update-site</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern-jsdt-feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/update-site/tern-linters-feature/feature.xml
+++ b/update-site/tern-linters-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tern-linters-feature"
       label="%featureName"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.0.qualifier">

--- a/update-site/tern-linters-feature/pom.xml
+++ b/update-site/tern-linters-feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>update-site</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern-linters-feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/update-site/tern-server-nodejs-feature/feature.xml
+++ b/update-site/tern-server-nodejs-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tern-server-nodejs-feature"
       label="%featureName"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.0.qualifier">

--- a/update-site/tern-server-nodejs-feature/pom.xml
+++ b/update-site/tern-server-nodejs-feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>update-site</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern-server-nodejs-feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/update-site/tern-server-rhino-feature/feature.xml
+++ b/update-site/tern-server-rhino-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tern-server-rhino-feature"
       label="%featureName"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.0.qualifier">

--- a/update-site/tern-server-rhino-feature/pom.xml
+++ b/update-site/tern-server-rhino-feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>update-site</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern-server-rhino-feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/update-site/tern.eclipse.ide.server.nodejs.embed/feature.xml
+++ b/update-site/tern.eclipse.ide.server.nodejs.embed/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tern.eclipse.ide.server.nodejs.embed"
       label="%featureName"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.0.qualifier">

--- a/update-site/tern.eclipse.ide.server.nodejs.embed/pom.xml
+++ b/update-site/tern.eclipse.ide.server.nodejs.embed/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>update-site</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern.eclipse.ide.server.nodejs.embed</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/update-site/tern.eclipse.ide.tools.feature/feature.xml
+++ b/update-site/tern.eclipse.ide.tools.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tern.eclipse.ide.tools.feature"
       label="%featureName"
-      version="1.2.0.qualifier"
+      version="1.2.1.qualifier"
       provider-name="%featureProvider"
       license-feature="org.eclipse.license"
       license-feature-version="1.0.0.qualifier">

--- a/update-site/tern.eclipse.ide.tools.feature/pom.xml
+++ b/update-site/tern.eclipse.ide.tools.feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fr.opensagres.js</groupId>
     <artifactId>update-site</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>tern.eclipse.ide.tools.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/update-site/tern.repository/pom.xml
+++ b/update-site/tern.repository/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>update-site</artifactId>
-		<version>1.2.0</version>
+		<version>1.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>tern.repository</artifactId>
 	<packaging>eclipse-repository</packaging>


### PR DESCRIPTION
JBDS-4132 Could not load nodeJSInstall: node-v0.10.22-linux-x86_64 (branch 1.2.x)

The destination directory for unpacking the Node.js runtime is changed
from plugins installation directories to /.metadata/.plugins/ directory in user's workspace
in order to prevent the attempts to extract the runtime zip-archive into the directories with
restricted access rights.

See: https://issues.jboss.org/browse/JBDS-4132
Issue: #441 Could not load nodeJSInstall: node-v0.10.22-linux-x86_64
Signed-off-by: Victor Rubezhny vrubezhny@redhat.com