### PR TITLE
Update tern.server.j2v8 parent pom version number

### DIFF
--- a/core/tern.server.j2v8/pom.xml
+++ b/core/tern.server.j2v8/pom.xml
@@ -5,6 +5,6 @@
 	<parent>
 		<groupId>fr.opensagres.js</groupId>
 		<artifactId>core</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 </project>


### PR DESCRIPTION
It seems the version number of the parent pom had not been updated.